### PR TITLE
Update foundry.mdx

### DIFF
--- a/build-on-abstract/smart-contracts/foundry.mdx
+++ b/build-on-abstract/smart-contracts/foundry.mdx
@@ -24,26 +24,16 @@ To use Foundry to build smart contracts on Abstract, use the [foundry-zksync](ht
 </Note>
 
 <Steps>
-  <Step title="Clone the repository">
-  From any directory, clone the `foundry-zksync` repository.
+  <Step title="Install Script">
+  In '~' directory, run the following line from the [Foundry-zksync book](https://foundry-book.zksync.io/getting-started/installation).
 
 ```bash
-git clone https://github.com/matter-labs/foundry-zksync.git
+curl -L https://raw.githubusercontent.com/matter-labs/foundry-zksync/main/install-foundry-zksync | bash
 ```
-
   </Step>
+
   <Step title="Run the installer">
   Change directory into the `foundry-zksync` directory.
-
-```bash
-cd foundry-zksync
-```
-
-Run the installer:
-
-```bash
-./install-foundry-zksync
-```
 
   <Accordion title="Common installation issues" icon="circle-exclamation">
     


### PR DESCRIPTION
Instead of the normal clone in any directory, want to recommend a change since we have already set the premise that this would replace current foundry binary, i recommend to use the curl request from the [Foundry-zksync book](https://foundry-book.zksync.io/getting-started/installation) itself, as it installs the script directly and prevents output issues which i was currently facing

![Screenshot 2024-09-28 at 10 58 07 am](https://github.com/user-attachments/assets/6f809de8-fe47-4c87-a82a-6d4b4b3b57da)
there are such issues also raised in the foundry-zksync repo too