### PR TITLE
Docs: Fixed misspelled

### DIFF
--- a/build-on-abstract/smart-contracts/hardhat.mdx
+++ b/build-on-abstract/smart-contracts/hardhat.mdx
@@ -141,7 +141,7 @@ contract HelloAbstract {
 
 ## 5. Compile the smart contract
 
-Clear any existing artrifacts:
+Clear any existing artifacts:
 
 ```bash
 npx hardhat clean


### PR DESCRIPTION
In the section 5 "Compile the smart contract," the sentence "Clear any existing artrifacts" should be corrected to "Clear any existing artifacts."