### PR TITLE
fix connect-to-abstract.mdx

### DIFF
--- a/connect-to-abstract.mdx
+++ b/connect-to-abstract.mdx
@@ -13,7 +13,7 @@ Use the information below to connect and submit transactions to Abstract.
 | Description         | The public testnet for Abstract.                                    |
 | Chain ID            | `11124`                                                             |
 | RPC URL             | `https://api.testnet.abs.xyz`                                       |
-| RPC URL (Websocket) | `ws://api.testnet.abs.xyz/ws`                                       |
+| RPC URL (Websocket) | `wss://api.testnet.abs.xyz/ws`                                       |
 | Explorer            | `https://explorer.testnet.abs.xyz`                                  |
 | Verify URL          | `https://api-explorer-verify.testnet.abs.xyz/contract_verification` |
 | Currency Symbol     | ETH                                                                 |


### PR DESCRIPTION
Websocket URL in connect-to-abstract.mdx has been updated from ws:// to wss:// protocol for enhanced connection security.