### PR TITLE
docs: fix typos

### DIFF
--- a/abstract-global-wallet/agw-client/getting-started.mdx
+++ b/abstract-global-wallet/agw-client/getting-started.mdx
@@ -21,7 +21,7 @@ npm install @abstract-foundation/agw-client viem
 
 ## 2. Instantiate a client
 
-Use the [createAbstractClient](/abstract-global-wallet/agw-client/createAbstractClient) function to instantiate a new isntance of the `AbstractClient`.
+Use the [createAbstractClient](/abstract-global-wallet/agw-client/createAbstractClient) function to instantiate a new instance of the `AbstractClient`.
 
 The `signer` field is the EOA that owns the Abstract Global Wallet smart contract. If this account has not yet created an Abstract Global Wallet,
 the first transaction they send will first deploy one, set the account as the owner and then continue with the transaction.

--- a/how-abstract-works/evm-differences/evm-opcodes.mdx
+++ b/how-abstract-works/evm-differences/evm-opcodes.mdx
@@ -156,7 +156,7 @@ Returns a constant value of `2500000000000000` on Abstract.
 
 ## `BASEFEE`
 
-This is not a constant on Absrtact and is instead defined by the fee model. Most
+This is not a constant on Abstract and is instead defined by the fee model. Most
 of the time it is 0.25 gwei, but under very high L1 gas prices it may rise.
 
 ## `SELFDESTRUCT`

--- a/how-abstract-works/evm-differences/gas-fees.mdx
+++ b/how-abstract-works/evm-differences/gas-fees.mdx
@@ -9,7 +9,7 @@ the [transaction lifecycle](/how-abstract-works/architecture/transaction-lifecyc
 section, Abstract posts state diffs _(as well as compressed contract bytecode)_ to Ethereum
 in the form of [blobs](https://www.eip4844.com/).
 
-In addition to the cost of posting blobs, their are costs associated with generating
+In addition to the cost of posting blobs, there are costs associated with generating
 ZK proofs for batches and committing & verifying these proofs on Ethereum.
 
 To fairly distribute

--- a/how-abstract-works/native-account-abstraction/handling-nonces.mdx
+++ b/how-abstract-works/native-account-abstraction/handling-nonces.mdx
@@ -3,7 +3,7 @@ title: "Handling Nonces"
 description: "Learn the best practices for handling nonces when building smart contract accounts on Abstract."
 ---
 
-As outlined in the [tranasction flow](/how-abstract-works/native-account-abstraction/transaction-flow), a call to `validateNonceUsage`
+As outlined in the [transaction flow](/how-abstract-works/native-account-abstraction/transaction-flow), a call to `validateNonceUsage`
 is made to the [NonceHolder](/how-abstract-works/system-contracts/list-of-system-contracts#nonceholder) system contract
 before each transaction starts, in order to check whether the provided nonce
 of a transaction has already been used or not.

--- a/how-abstract-works/system-contracts/list-of-system-contracts.mdx
+++ b/how-abstract-works/system-contracts/list-of-system-contracts.mdx
@@ -209,7 +209,7 @@ The [ContractDeployer](#contractdeployer) checks this `KnownCodesStorage` contra
 code hash of a smart contract is known before deploying it. If it is not known,
 the contract will not be deployed and revert with an error `The code hash is not known`.
 
-<Accordion title={`Why am i getting "the code hash is not known" error?`}>
+<Accordion title={`Why am I getting "the code hash is not known" error?`}>
   Likely, you are trying to deploy a smart contract without using the 
   [ContractDeployer](#contractdeployer) sytstem contract.
 

--- a/how-abstract-works/system-contracts/using-system-contracts.mdx
+++ b/how-abstract-works/system-contracts/using-system-contracts.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Using System Contracts"
-description: "Undersand how to best use system contracts on Abstract."
+description: "Understand how to best use system contracts on Abstract."
 ---
 
 When building smart contracts on Abstract, you often need to interact directly with **system contracts**


### PR DESCRIPTION
# Changes

Typo correction


# Description

I'v been checked every 'md', 'mdx' files in this repository and found some typos that needed to be fixed because they clearly changed the meaning and fixed them.

There were also some awkward wording and punctuation, but I didn't fix those because they don't detract too much from the meaning of the original documentation and don't cause any problems in understanding the documentation.

Each commit explains which typos are corrected and reason. Hope this helps and wish success with the project.