### PR TITLE
Update prover-and-verifier.mdx

### DIFF
--- a/how-abstract-works/architecture/components/prover-and-verifier.mdx
+++ b/how-abstract-works/architecture/components/prover-and-verifier.mdx
@@ -78,7 +78,7 @@ The proof generation process is composed of three main steps:
     a type of validity proof that is relatively large and therefore would be more costly 
     to post on Ethereum to be verified.
 
-    For this reason, a final compression step is performed to generate a succint validity proof
+    For this reason, a final compression step is performed to generate a succinct validity proof
     called a [ZK-SNARK](https://ethereum.org/en/developers/docs/scaling/zk-rollups/#validity-proofs)
     that can be [verified](#proof-verification) quickly and cheaply on Ethereum.
 


### PR DESCRIPTION
corrected small spelling typo, from "**succint**" to "**succinct**"

![image](https://github.com/user-attachments/assets/7a6fa8ea-3104-4f4e-86ac-25ab0c6694af)

