### PR TITLE
Fix Typo: Correct 'it's' to 'its' and Fix Comma Splic

### DIFF
--- a/build-on-abstract/getting-started.mdx
+++ b/build-on-abstract/getting-started.mdx
@@ -3,7 +3,7 @@ title: "Getting Started"
 description: "Learn how to start developing smart contracts and applications on Abstract."
 ---
 
-Abstract is EVM compatible, however, there are [differences](/how-abstract-works/evm-differences/overview)
+Abstract is EVM compatible; however, there are [differences](/how-abstract-works/evm-differences/overview)
 between Abstract and Ethereum that enable more powerful user experiences. For developers, additional configuration may be required
 to accommodate these changes and take full advantage of Abstract's capabilities.
 

--- a/how-abstract-works/architecture/components/prover-and-verifier.mdx
+++ b/how-abstract-works/architecture/components/prover-and-verifier.mdx
@@ -101,7 +101,7 @@ submitted with the `proveBatches` function call to the
 [transaction lifecycle](/how-abstract-works/architecture/transaction-lifecycle) section.
 
 The ZK proof is then verified by the verifier smart contract on Ethereum by calling
-it&rsquo;s `verify` function and providing the proof as an argument.
+its `verify` function and providing the proof as an argument.
 
 ```solidity
 // Returns a boolean value indicating whether the zk-SNARK proof is valid.

--- a/overview.mdx
+++ b/overview.mdx
@@ -58,7 +58,7 @@ Use our tutorials to kickstart your development journey on Abstract.
 
 ## Learn more about Abstract
 
-Dive deeper into how Abstract works and how you can leverage it&rsquo;s features.
+Dive deeper into how Abstract works and how you can leverage its features.
 
 <CardGroup cols={2}>
   <Card title="What is Abstract?" icon="question" href="/what-is-abstract">


### PR DESCRIPTION
Corrections made:

Context - 1  : (Possessive "its" corrected; "it's" was incorrectly used as a contraction.)

> **1. "how you can leverage it’s features" → "how you can leverage its features"
> 2. "it’s verify function" → "its verify function"**

Context - 2  : (` ,→ ; ` Comma splice corrected; a semicolon was used to separate two independent clauses properly.) 

> **1. "Abstract is EVM compatible, however, there are differences..." → "Abstract is EVM compatible; however, there are differences..."**

