### PR TITLE
Update faucets.mdx , transaction-flow.mdx , contract-deployment.mdx

### DIFF
--- a/how-abstract-works/evm-differences/contract-deployment.mdx
+++ b/how-abstract-works/evm-differences/contract-deployment.mdx
@@ -19,7 +19,7 @@ If the bytecode of the contract has not been published, the deployment transacti
 
 To publish bytecode before deployment, all contract deployments on Abstract are performed by calling the 
 [ContractDeployer](/how-abstract-works/system-contracts/list-of-system-contracts#contractdeployer) system contract
-using one of it&rsquo;s
+using one of its
 [create](#create),
 [create2](#create2),
 [createAccount](#createaccount), or

--- a/how-abstract-works/native-account-abstraction/transaction-flow.mdx
+++ b/how-abstract-works/native-account-abstraction/transaction-flow.mdx
@@ -33,7 +33,7 @@ Since all accounts on Abstract are smart contracts, all transactions go through 
       icon="boot"
       href="/how-abstract-works/system-contracts/bootloader"
     >
-        Learn more about the bootloader system contract and it&rsquo;s role in processing transactions.
+        Learn more about the bootloader system contract and its role in processing transactions.
     </Card>
 
 </Step>

--- a/tooling/faucets.mdx
+++ b/tooling/faucets.mdx
@@ -6,7 +6,7 @@ description: "Learn how to easily get testnet funds for development on Abstract.
 Faucets distribute small amounts of testnet ETH to enable developers & users to deploy and
 interact with smart contracts on the testnet.
 
-Abstract has it&rsquo;s own testnet that uses
+Abstract has its own testnet that uses
 the [Sepolia](https://ethereum.org/en/developers/docs/networks/#sepolia) network as the L1, meaning
 you can get testnet ETH on Abstract directly or [bridge](/tooling/bridges) Sepolia ETH to the
 Abstract testnet.


### PR DESCRIPTION
 typo fix: it’s → its (possessive form).