### PR TITLE
Fix(useAbstractClient.mdx): typos in documentation: corrected "the the" to "the"

### DIFF
--- a/abstract-global-wallet/agw-react/hooks/useAbstractClient.mdx
+++ b/abstract-global-wallet/agw-react/hooks/useAbstractClient.mdx
@@ -6,7 +6,7 @@ description: Hook for creating and managing an Abstract client instance.
 import TanStackQueryReturnTypeSnippet from "/snippets/tanstack-query-return-type.mdx";
 
 Gets the [Wallet client](https://viem.sh/docs/clients/wallet)
-exposed by the the [AbstractWalletProvider](/abstract-global-wallet/agw-react/AbstractWalletProvider) context.
+exposed by the [AbstractWalletProvider](/abstract-global-wallet/agw-react/AbstractWalletProvider) context.
 Use this client to perform actions from the connected Abstract Global Wallet, for example
 [deployContract](/abstract-global-wallet/agw-client/actions/deployContract),
 [sendTransaction](/abstract-global-wallet/agw-client/actions/sendTransaction),


### PR DESCRIPTION
 "the the" to "the"