### PR TITLE
Update connect-to-abstract.mdx

### DIFF
--- a/connect-to-abstract.mdx
+++ b/connect-to-abstract.mdx
@@ -9,12 +9,12 @@ Use the information below to connect and submit transactions to Abstract.
 
 | Property            | Description                                                         |
 | ------------------- | ------------------------------------------------------------------- |
-| Name                | Abstract Testnet                                                    |
+| Name                | Abstract Sepolia Testnet                                            |
 | Description         | The public testnet for Abstract.                                    |
 | Chain ID            | `11124`                                                             |
 | RPC URL             | `https://api.testnet.abs.xyz`                                       |
 | RPC URL (Websocket) | `wss://api.testnet.abs.xyz/ws`                                       |
-| Explorer            | `https://explorer.testnet.abs.xyz`                                  |
+| Explorer            | `https://sepolia.abscan.org` or `https://explorer.testnet.abs.xyz`   |
 | Verify URL          | `https://api-explorer-verify.testnet.abs.xyz/contract_verification` |
 | Currency Symbol     | ETH                                                                 |
 
@@ -28,7 +28,20 @@ Once connected, use a [bridge](/tooling/bridges) or
 
 ## Mainnet
 
-Abstract Mainnet is coming soon.
+| Property            | Description                                                         |
+| ------------------- | ------------------------------------------------------------------- |
+| Name                | Abstract Mainnet                                                    |
+| Description         | The public mainnet for Abstract.                                    |
+| Chain ID            | `2741`                                                              |
+| RPC URL             | `TBA`                                                               |
+| RPC URL (Websocket) | `TBA`                                                               |
+| Explorer            | `https://abscan.org/`                                               |
+| Verify URL          | `TBA`                                                               |
+| Currency Symbol     | ETH                                                                 |
+
+<Tip>
+  Abstract Mainnet is coming soon in January 2025
+</Tip>
 
 export const ConnectWallet = ({ title }) => {
   if (typeof document === "undefined") {


### PR DESCRIPTION
Testnet

adding more explorer url with etherscan format and adjust the name just in case we have additional testnet with different building environment in the future

Mainnet 

Rely based on Testnet Format and adding public data without RPC, Websocket, Verify URL with tip, might consider move to the top section once mainnet launch