### PR TITLE
Add missing paymaster params to paymaster example

### DIFF
--- a/abstract-global-wallet/agw-client/actions/writeContract.mdx
+++ b/abstract-global-wallet/agw-client/actions/writeContract.mdx
@@ -100,6 +100,10 @@ const transactionHash = await agwClient.writeContract({
   address: "0xC4822AbB9F05646A9Ce44EFa6dDcda0Bf45595AA",
   functionName: "mint",
   args: ["0x273B3527BF5b607dE86F504fED49e1582dD2a1C6", BigInt(1)],
+  paymaster: "0x5407B5040dec3D339A9247f3654E59EEccbb6391",
+  paymasterInput: getGeneralPaymasterInput({
+    innerInput: "0x",
+  }),
 });
 ```
 


### PR DESCRIPTION
Add missing paymaster params to paymaster example on the collapsible in page: 
- https://docs.abs.xyz/abstract-global-wallet/agw-client/actions/writeContract#param-paymaster-input

Before:
```tsx
import { agwClient } from "./config";
import { parseAbi } from "viem";

const transactionHash = await agwClient.writeContract({
  abi: parseAbi(["function mint(address,uint256) external"]),
  address: "0xC4822AbB9F05646A9Ce44EFa6dDcda0Bf45595AA",
  functionName: "mint",
  args: ["0x273B3527BF5b607dE86F504fED49e1582dD2a1C6", BigInt(1)],
});
```

After:
```tsx
import { agwClient } from "./config";
import { parseAbi } from "viem";

const transactionHash = await agwClient.writeContract({
  abi: parseAbi(["function mint(address,uint256) external"]),
  address: "0xC4822AbB9F05646A9Ce44EFa6dDcda0Bf45595AA",
  functionName: "mint",
  args: ["0x273B3527BF5b607dE86F504fED49e1582dD2a1C6", BigInt(1)],
  paymaster: "0x5407B5040dec3D339A9247f3654E59EEccbb6391",
  paymasterInput: getGeneralPaymasterInput({
    innerInput: "0x",
  }),
});
```