### PR TITLE
delete space getSmartAccountAddressFromInitialSigner.mdx

### DIFF
--- a/abstract-global-wallet/agw-client/getSmartAccountAddressFromInitialSigner.mdx
+++ b/abstract-global-wallet/agw-client/getSmartAccountAddressFromInitialSigner.mdx
@@ -1,5 +1,5 @@
 ---
-title: "getSmartAccountAddress FromInitialSigner"
+title: "getSmartAccountAddressFromInitialSigner"
 description: "Function to deterministically derive the deployed Abstract Global Wallet smart account address from the initial signer account."
 ---
 


### PR DESCRIPTION
In the file title getSmartAccountAddress FromInitialSigner, there's an extra space. It should be changed to getSmartAccountAddressFromInitialSigner to match the function name.