### PR TITLE
Correcting Phrasing

### DIFF
--- a/abstract-global-wallet/agw-client/wallet-linking/overview.mdx
+++ b/abstract-global-wallet/agw-client/wallet-linking/overview.mdx
@@ -9,7 +9,7 @@ You may want to allow users to perform actions with their Abstract Global Wallet
 - Check if a user is whitelisted for an NFT mint based on their Ethereum Mainnet wallet.
 - Read what NFTs or tokens the user holds in their Ethereum Mainnet wallet.
 
-For these use cases, Abstract provides the [DelegateRegistry](https://sepolia.abscan.org/address/0x0000000059A24EB229eED07Ac44229DB56C5d797#code#F1#L16) contract to that allows users to make a *link* between their Ethereum Mainnet wallet and their AGW.
+For these use cases, Abstract provides the [DelegateRegistry](https://sepolia.abscan.org/address/0x0000000059A24EB229eED07Ac44229DB56C5d797#code#F1#L16) contract that allows users to create a *link* between their Ethereum Mainnet wallet and their AGW.
 
 This link is created by having users sign a transaction on Ethereum Mainnet that includes their Abstract Global Wallet address; creating a way for applications to read what wallets are linked to an AGW.
 


### PR DESCRIPTION
removed "to" and replaced "make a link" with "create a link" for better precision and readability