### PR TITLE
Fixing Grammatical Errors in Documentation

### DIFF
--- a/abstract-global-wallet/agw-react/overview.mdx
+++ b/abstract-global-wallet/agw-react/overview.mdx
@@ -8,7 +8,7 @@ icon: "react"
 The `agw-react` package provides a set of hooks and components that allow users to sign in and send
 transactions using Abstract Global Wallet. **It is built on top of the [wagmi](https://wagmi.sh/) library.**
 
-Once the user connect&rsquo;s their wallet by calling [useLoginWithAbstract](/abstract-global-wallet/agw-react/hooks/useLoginWithAbstract) _(within the context
+Once the user connects their wallet by calling [useLoginWithAbstract](/abstract-global-wallet/agw-react/hooks/useLoginWithAbstract) _(within the context
 of an [AbstractWalletProvider](/abstract-global-wallet/agw-react/AbstractWalletProvider)_),
 you can continue to use any of the [wagmi](https://wagmi.sh/) and [TanStack Query](https://tanstack.com/query/latest/docs/framework/react/overview)
 hooks as you would with any other wallet, as well as all of the [viem](https://viem.sh/) functionality.

--- a/snippets/tanstack-query-return-type.mdx
+++ b/snippets/tanstack-query-return-type.mdx
@@ -94,9 +94,8 @@ A function to manually refetch the query.
   property has the error received from the attempted fetch.
 - `success`: if the query has received a response with no errors and is ready to display its data.
 
-The corresponding data property on the query is the data received from the
-successful fetch or if the query's enabled property is set to successful fetch
-or if the query's enabled property is set to false and has not been fetched
-yet data is the first initialData supplied to the query on initialization.
+  The corresponding data property on the query is the data received from the
+  successful fetch or if the query's enabled property is set to false and has not been fetched
+  yet, data is the first initialData supplied to the query on initialization.
 
 </ResponseField>


### PR DESCRIPTION


#### Changes Made:

1. **File:** `abstract-global-wallet/agw-react/overview.mdx`
   - **Old Text:** "Once the user connect’s their wallet by calling
   - **New Text:** "Once the user connects their wallet by calling 
   - **Reason:** Corrected "connect’s" to "connects."

2. **File:** `snippets/tanstack-query-return-type.mdx`
   - **Old Text:** "or if the query's enabled property is set to successful fetch or if the query's enabled property is set to false and has not been fetched yet data is the first initialData supplied to the query on initialization."
   - **New Text:** "or if the query's enabled property is set to false and has not been fetched yet, data is the first initialData supplied to the query on initialization."
   - **Reason:** Improved clarity and added a comma for readability.

#### Summary:
These changes enhance grammatical accuracy and clarity in the documentation.