### PR TITLE
Grammar and Clarity Improvements in Documentation

### DIFF
--- a/abstract-global-wallet/agw-react/getting-started.mdx
+++ b/abstract-global-wallet/agw-react/getting-started.mdx
@@ -24,7 +24,7 @@ npx @abstract-foundation/create-abstract-app@latest my-app
       />
     }
   >
-    Add AGW as the native wallet connection option to your React application.
+    Add AGW as the native wallet connection option for your React application.
   </Card>
   <Card
     title="Privy"
@@ -48,7 +48,7 @@ npx @abstract-foundation/create-abstract-app@latest my-app
       />
     }
   >
-    Integrate AGW as a wallet connection option to an existing ConnectKit
+    Integrate AGW as a wallet connection option for an existing ConnectKit
     application.
   </Card>
   <Card
@@ -61,7 +61,7 @@ npx @abstract-foundation/create-abstract-app@latest my-app
       />
     }
   >
-    Integrate AGW as a wallet connection option to an existing Dynamic
+    Integrate AGW as a wallet connection option for an existing Dynamic
     application.
   </Card>
   <Card
@@ -74,7 +74,7 @@ npx @abstract-foundation/create-abstract-app@latest my-app
       />
     }
   >
-    Integrate AGW as a wallet connection option to an existing RainbowKit
+    Integrate AGW as a wallet connection option for an existing RainbowKit
     application.
   </Card>
   <Card
@@ -87,7 +87,7 @@ npx @abstract-foundation/create-abstract-app@latest my-app
       />
     }
   >
-    Integrate AGW as a wallet connection option to an existing thirdweb
+    Integrate AGW as a wallet connection option for an existing thirdweb
     application.
   </Card>
 </CardGroup>

--- a/abstract-global-wallet/getting-started.mdx
+++ b/abstract-global-wallet/getting-started.mdx
@@ -26,7 +26,7 @@ Integrate Abstract Global Wallet into an existing project using one of our integ
       />
     }
   >
-    Add AGW as the native wallet connection option to your React application.
+    Add AGW as the native wallet connection option for your React application.
   </Card>
   <Card
     title="Privy"
@@ -50,7 +50,7 @@ Integrate Abstract Global Wallet into an existing project using one of our integ
       />
     }
   >
-    Integrate AGW as a wallet connection option to an existing ConnectKit
+    Integrate AGW as a wallet connection option for an existing ConnectKit
     application.
   </Card>
   <Card
@@ -63,7 +63,7 @@ Integrate Abstract Global Wallet into an existing project using one of our integ
       />
     }
   >
-    Integrate AGW as a wallet connection option to an existing Dynamic
+    Integrate AGW as a wallet connection option for an existing Dynamic
     application.
   </Card>
   <Card
@@ -76,7 +76,7 @@ Integrate Abstract Global Wallet into an existing project using one of our integ
       />
     }
   >
-    Integrate AGW as a wallet connection option to an existing RainbowKit
+    Integrate AGW as a wallet connection option for an existing RainbowKit
     application.
   </Card>
   <Card


### PR DESCRIPTION
 Changed "to" to "for" for improved clarity and correctness.