### PR TITLE
Fix Documentation Links 

### DIFF
--- a/abstract-global-wallet/agw-client/overview.mdx
+++ b/abstract-global-wallet/agw-client/overview.mdx
@@ -5,7 +5,7 @@ description: "Learn how the agw-client package works and how to use it to intera
 icon: "js"
 ---
 
-The `agw-client` package exposes an [AbstractClient](/abstract-global-wallet/agw-client/createAbstractClient),
+The `agw-client` package exposes an [AbstractClient](/abstract-global-wallet/agw-client/createAbstractClient.mdx),
 built on top of the [Viem Wallet Client](https://viem.sh/docs/clients/wallet.html)
 that allows you to deploy contracts, submit transactions, and more from the Abstract Global Wallet.
 

--- a/abstract-global-wallet/agw-react/getting-started.mdx
+++ b/abstract-global-wallet/agw-react/getting-started.mdx
@@ -142,10 +142,10 @@ meaning you can use the hooks and features of these libraries within your applic
 
 ### 3. Use React Hooks
 
-With the provider setup, you can now use any of the available [hooks](/abstract-global-wallet/agw-react/hooks/useAbstractClient)
+With the provider setup, you can now use any of the available [hooks](/abstract-global-wallet/agw-react/hooks/useAbstractClient.mdx)
 from the `agw-react` package inside
 any component within your application. To prompt the user to sign in with AGW, use the
-[useLoginWithAbstract](/abstract-global-wallet/agw-react/hooks/useLoginWithAbstract) hook.
+[useLoginWithAbstract](/abstract-global-wallet/agw-react/hooks/useLoginWithAbstract.mdx) hook.
 
 ```tsx
 import { useLoginWithAbstract } from "@abstract-foundation/agw-react";
@@ -161,7 +161,7 @@ export default function SignIn() {
 ### 4. Use wagmi hooks
 
 Once the user has signed in, you can begin to use any of the `agw-react` hooks,
-such as [useWriteContractSponsored](/abstract-global-wallet/agw-react/hooks/useWriteContractSponsored)
+such as [useWriteContractSponsored](/abstract-global-wallet/agw-react/hooks/useWriteContractSponsored.mdx)
 as well as all of the existing [wagmi hooks](https://wagmi.sh/react/api/hooks); such as [useAccount](https://wagmi.sh/react/api/hooks/useAccount),
 [useBalance](https://wagmi.sh/react/api/hooks/useBalance), etc.
 
@@ -192,12 +192,12 @@ export default function SendTransactionWithWagmi() {
 
 ### 5. Use the client directly
 
-The [AbstractClient](/abstract-global-wallet/agw-client/createAbstractClient)
-also exposes a set of [actions](/abstract-global-wallet/agw-client/actions/deployContract)
+The [AbstractClient](/abstract-global-wallet/agw-client/createAbstractClient.mdx)
+also exposes a set of [actions](/abstract-global-wallet/agw-client/actions/deployContract.mdx)
 you can use to interact with the wallet, including
-[deploying a contract](/abstract-global-wallet/agw-client/actions/deployContract),
-[sending a transaction](/abstract-global-wallet/agw-client/actions/sendTransaction),
-or [calling a contract function](/abstract-global-wallet/agw-client/actions/writeContract).
+[deploying a contract](/abstract-global-wallet/agw-client/actions/deployContract.mdx),
+[sending a transaction](/abstract-global-wallet/agw-client/actions/sendTransaction.mdx),
+or [calling a contract function](/abstract-global-wallet/agw-client/actions/writeContract.mdx).
 
 ```tsx
 import { useGlobalWalletSignerClient } from "@abstract-foundation/agw-react";

--- a/abstract-global-wallet/agw-react/overview.mdx
+++ b/abstract-global-wallet/agw-react/overview.mdx
@@ -8,8 +8,8 @@ icon: "react"
 The `agw-react` package provides a set of hooks and components that allow users to sign in and send
 transactions using Abstract Global Wallet. **It is built on top of the [wagmi](https://wagmi.sh/) library.**
 
-Once the user connects their wallet by calling [useLoginWithAbstract](/abstract-global-wallet/agw-react/hooks/useLoginWithAbstract) _(within the context
-of an [AbstractWalletProvider](/abstract-global-wallet/agw-react/AbstractWalletProvider)_),
+Once the user connects their wallet by calling [useLoginWithAbstract](/abstract-global-wallet/agw-react/hooks/useLoginWithAbstract.mdx) _(within the context
+of an [AbstractWalletProvider](/abstract-global-wallet/agw-react/AbstractWalletProvider.mdx)_),
 you can continue to use any of the [wagmi](https://wagmi.sh/) and [TanStack Query](https://tanstack.com/query/latest/docs/framework/react/overview)
 hooks as you would with any other wallet, as well as all of the [viem](https://viem.sh/) functionality.
 
@@ -18,13 +18,13 @@ hooks as you would with any other wallet, as well as all of the [viem](https://v
 Both wagmi and TanStack Query wrap your application in a **provider** component that allows you
 to use the hooks and components they provide anywhere in your application.
 
-The `agw-react` package similarly provides the [AbstractWalletProvider](/abstract-global-wallet/agw-react/AbstractWalletProvider) component,
+The `agw-react` package similarly provides the [AbstractWalletProvider](/abstract-global-wallet/agw-react/AbstractWalletProvider.mdx) component,
 which under the hood wraps your application in the following providers:
 
 1. The TanStack [QueryClientProvider](https://tanstack.com/query/latest/docs/framework/react/reference/QueryClientProvider):
    to manage your application's state using [queries](https://wagmi.sh/react/guides/tanstack-query) and [mutations](https://wagmi.sh/react/guides/tanstack-query),
    e.g. to check if a wallet is connected, read data from the blockchain, and send transactions.
-2. The wagmi [WagmiProvider](https://wagmi.sh/react/api/WagmiProvider): configured to use the Abstract [network](/connect-to-abstract)
+2. The wagmi [WagmiProvider](https://wagmi.sh/react/api/WagmiProvider): configured to use the Abstract [network](/connect-to-abstract.mdx)
    with Abstract Global Wallet as a [wallet connection option](https://wagmi.sh/react/guides/connect-wallet).
 
 Learn more about the [wagmi](https://wagmi.sh/) and [TanStack Query](https://tanstack.com/query/latest/docs/framework/react/overview)

--- a/abstract-global-wallet/architecture.mdx
+++ b/abstract-global-wallet/architecture.mdx
@@ -4,7 +4,7 @@ description: "Learn more about how Abstract Global Wallet works under the hood."
 ---
 
 Abstract Global Wallet makes use of [native account abstraction](/how-abstract-works/native-account-abstraction),
-by creating [smart contract wallets](/how-abstract-works/native-account-abstraction/smart-contract-wallets)
+by creating [smart contract wallets](/how-abstract-works/native-account-abstraction/smart-contract-wallets.mdx)
 for users that have more security and flexibility than traditional EOAs.
 
 Users can connect their Abstract Global Wallet to an application by logging in with their email, social account, or existing wallet.
@@ -107,7 +107,7 @@ of any two shards, the most common being the **Device Share** and **Auth Share**
 ### Smart Contract Wallet Deployment
 
 Once an EOA wallet is generated, the public key is provided to a
-[smart contract wallet](/how-abstract-works/native-account-abstraction/smart-contract-wallets) deployment.
+[smart contract wallet](/how-abstract-works/native-account-abstraction/smart-contract-wallets.mdx) deployment.
 The smart contract wallet is deployed and the EOA wallet is added as an authorized signer to the wallet during
 the initialization process.
 
@@ -126,7 +126,7 @@ The smart contract wallet includes many modules to extend the functionality of t
 
 - **Recovery Modules**: Allows the user to recover their account if they lose access to their login method via recovery methods
   including email or guardian recovery.
-- **Paymaster Support**: Transaction gas fees can be sponsored by [paymasters](/how-abstract-works/native-account-abstraction/paymasters).
+- **Paymaster Support**: Transaction gas fees can be sponsored by [paymasters](/how-abstract-works/native-account-abstraction/paymasters.mdx).
 - **Multiple Signers**: Users can add multiple signers to the wallet to allow for multiple different
   accounts to sign transactions.
 - **P256/secp256r1 Support**: Users can add signers generated from [passkeys](https://fidoalliance.org/passkeys/)

--- a/abstract-global-wallet/overview.mdx
+++ b/abstract-global-wallet/overview.mdx
@@ -13,7 +13,7 @@ npx @abstract-foundation/create-abstract-app@latest my-app
 ## What is Abstract Global Wallet?
 
 Abstract Global Wallet (AGW) is a cross-application
-[smart contract wallet](/how-abstract-works/native-account-abstraction/smart-contract-wallets) that
+[smart contract wallet](/how-abstract-works/native-account-abstraction/smart-contract-wallets.mdx) that
 users can create to interact with any application built on Abstract,
 powered by [native account abstraction](/how-abstract-works/native-account-abstraction).
 

--- a/build-on-abstract/applications/viem.mdx
+++ b/build-on-abstract/applications/viem.mdx
@@ -4,8 +4,8 @@ description: "Learn how to use the Viem library to build applications on Abstrac
 ---
 
 The Viem library has first-class support for Abstract by providing a set of
-extensions to interact with [paymasters](/how-abstract-works/native-account-abstraction/paymasters),
-[smart contract wallets](/how-abstract-works/native-account-abstraction/smart-contract-wallets), and more.
+extensions to interact with [paymasters](/how-abstract-works/native-account-abstraction/paymasters.mdx),
+[smart contract wallets](/how-abstract-works/native-account-abstraction/smart-contract-wallets.mdx), and more.
 This page will walk through how to configure Viem to utilize Abstract&rsquo;s features.
 
 <Accordion title="Prerequisites">
@@ -99,7 +99,7 @@ const transactionHash = await walletClient.sendTransaction({
 
 #### Paymasters
 
-Viem has native support for Abstract [paymasters](/how-abstract-works/native-account-abstraction/paymasters).
+Viem has native support for Abstract [paymasters](/how-abstract-works/native-account-abstraction/paymasters.mdx).
 
 Provide the `paymaster` and `paymasterInput` fields when sending a transaction.
 
@@ -115,7 +115,7 @@ const hash = await walletClient.sendTransaction({
 
 #### Smart Contract Wallets
 
-Viem also has native support for using [smart contract wallets](/how-abstract-works/native-account-abstraction/smart-contract-wallets).
+Viem also has native support for using [smart contract wallets](/how-abstract-works/native-account-abstraction/smart-contract-wallets.mdx).
 This means you can submit transactions `from` a smart contract wallet by providing
 a smart wallet account as the `account` field to the [client](#client-configuration).
 

--- a/build-on-abstract/getting-started.mdx
+++ b/build-on-abstract/getting-started.mdx
@@ -3,7 +3,7 @@ title: "Getting Started"
 description: "Learn how to start developing smart contracts and applications on Abstract."
 ---
 
-Abstract is EVM compatible; however, there are [differences](/how-abstract-works/evm-differences/overview)
+Abstract is EVM compatible; however, there are [differences](/how-abstract-works/evm-differences/overview.mdx)
 between Abstract and Ethereum that enable more powerful user experiences. For developers, additional configuration may be required
 to accommodate these changes and take full advantage of Abstract's capabilities.
 

--- a/build-on-abstract/smart-contracts/foundry.mdx
+++ b/build-on-abstract/smart-contracts/foundry.mdx
@@ -197,7 +197,7 @@ Transaction hash: 0x2a4c7c32f26b078d080836b247db3e6c7d0216458a834cfb8362a2ac84e6
   <Step title="Verify your smart contract on the block explorer" icon="check">
 
 Verifying your smart contract is helpful for others to view the code and
-interact with it from a [block explorer](/tooling/block-explorers).
+interact with it from a [block explorer](/tooling/block-explorers.mdx).
 To verify your smart contract, run the following command:
 
 <CodeGroup>

--- a/build-on-abstract/smart-contracts/hardhat.mdx
+++ b/build-on-abstract/smart-contracts/hardhat.mdx
@@ -52,14 +52,14 @@ Select your preferences when prompted by the CLI, or use the recommended setup b
 
 ## 2. Install the required dependencies
 
-Abstract smart contracts use [different bytecode](/how-abstract-works/evm-differences/overview)
+Abstract smart contracts use [different bytecode](/how-abstract-works/evm-differences/overview.mdx)
 than the Ethereum Virtual Machine (EVM).
 
 Install the required dependencies to compile, deploy and interact with smart contracts on Abstract:
 
 - [@matterlabs/hardhat-zksync](https://github.com/matter-labs/hardhat-zksync):
   A suite of Hardhat plugins for working with Abstract.
-- [zksync-ethers](/build-on-abstract/applications/ethers):
+- [zksync-ethers](/build-on-abstract/applications/ethers.mdx):
   Recommended package for writing [Hardhat scripts](https://hardhat.org/hardhat-runner/docs/advanced/scripts)
   to interact with your smart contracts.
 
@@ -132,7 +132,7 @@ export default config;
 
 ### Using system contracts
 
-To use [system contracts](/how-abstract-works/system-contracts/overview), install the `@matterlabs/zksync-contracts` package:
+To use [system contracts](/how-abstract-works/system-contracts/overview.mdx), install the `@matterlabs/zksync-contracts` package:
 
 ```bash
 npm install -D @matterlabs/zksync-contracts

--- a/how-abstract-works/evm-differences/evm-opcodes.mdx
+++ b/how-abstract-works/evm-differences/evm-opcodes.mdx
@@ -10,7 +10,7 @@ It is a fork of the [ZKsync EVM Instructions](https://docs.zksync.io/build/devel
 ## `CREATE` & `CREATE2`
 
 Deploying smart contracts on Abstract is different than
-Ethereum (see [contract deployment](/how-abstract-works/evm-differences/contract-deployment)).
+Ethereum (see [contract deployment](/how-abstract-works/evm-differences/contract-deployment.mdx)).
 To guarantee that `create` & `create2` functions operate correctly,
 the compiler must be aware of the bytecode of the deployed contract in advance.
 

--- a/how-abstract-works/evm-differences/gas-fees.mdx
+++ b/how-abstract-works/evm-differences/gas-fees.mdx
@@ -5,7 +5,7 @@ description: "Learn how Abstract differs from Ethereum's EVM opcodes."
 
 Abstract&rsquo;s gas fees depend on the fluctuating
 [gas prices](https://ethereum.org/en/developers/docs/gas/) on Ethereum. As mentioned in
-the [transaction lifecycle](/how-abstract-works/architecture/transaction-lifecycle)
+the [transaction lifecycle](/how-abstract-works/architecture/transaction-lifecycle.mdx)
 section, Abstract posts state diffs _(as well as compressed contract bytecode)_ to Ethereum
 in the form of [blobs](https://www.eip4844.com/).
 
@@ -22,11 +22,11 @@ Fees on Abstract therefore consist of both **off-chain** and **onchain** compone
 
 1. **Offchain Fee**:
    - Fixed cost (approximately $0.001 per transaction).
-   - Covers L2 state storage and zero-knowledge [proof generation](/how-abstract-works/architecture/components/prover-and-verifier#proof-generation).
+   - Covers L2 state storage and zero-knowledge [proof generation](/how-abstract-works/architecture/components/prover-and-verifier.mdx#proof-generation).
    - Independent of transaction complexity.
 2. **Onchain Fee**:
    - Variable cost (influenced by Ethereum gas prices).
-   - Covers [proof verification](/how-abstract-works/architecture/components/prover-and-verifier#proof-verification) and [publishing state](/how-abstract-works/architecture/transaction-lifecycle) on Ethereum.
+   - Covers [proof verification](/how-abstract-works/architecture/components/prover-and-verifier.mdx#proof-verification) and [publishing state](/how-abstract-works/architecture/transaction-lifecycle.mdx) on Ethereum.
 
 ## Differences from Ethereum
 

--- a/how-abstract-works/evm-differences/nonces.mdx
+++ b/how-abstract-works/evm-differences/nonces.mdx
@@ -10,7 +10,7 @@ accounts on Abstract maintain two different nonces:
 2. **Deployment nonce**: Incremented when a contract is deployed.
 
 In addition, nonces are not restricted to increment once per transaction
-like on Ethereum due to Abstract&rsquo;s [native account abstraction](/how-abstract-works/native-account-abstraction/overview).
+like on Ethereum due to Abstract&rsquo;s [native account abstraction](/how-abstract-works/native-account-abstraction/overview.mdx).
 
 <Card
   title="Handling Nonces in Smart Contract Wallets"

--- a/how-abstract-works/system-contracts/bootloader.mdx
+++ b/how-abstract-works/system-contracts/bootloader.mdx
@@ -12,7 +12,7 @@ The bootloader system contract plays several vital roles on Abstract, responsibl
 The bootloader processes transactions in batches that it
 receives from the [VM](https://docs.zksync.io/build/developer-reference/era-vm) and puts
 them all through the flow outlined in the
-[transaction flow](/how-abstract-works/native-account-abstraction/transaction-flow) section.
+[transaction flow](/how-abstract-works/native-account-abstraction/transaction-flow.mdx) section.
 
 <CardGroup cols={2}>
   <Card
@@ -34,13 +34,13 @@ them all through the flow outlined in the
 ## Bootloader Execution Flow
 
 1. As the bootloader receives batches of transactions from the VM, it sends the information
-   about the current batch to the [SystemContext system contract](/how-abstract-works/system-contracts/list-of-system-contracts#systemcontext)
+   about the current batch to the [SystemContext system contract](/how-abstract-works/system-contracts/list-of-system-contracts.mdx#systemcontext)
    before processing each transaction.
 
 2. As each transaction is processed, it goes through the flow outlined
-   in the [gas fees](/how-abstract-works/evm-differences/gas-fees) section.
+   in the [gas fees](/how-abstract-works/evm-differences/gas-fees.mdx) section.
 
-3. At the end of each batch, the bootloader informs the [L1Messenger system contract](/how-abstract-works/system-contracts/list-of-system-contracts#l1messenger)
+3. At the end of each batch, the bootloader informs the [L1Messenger system contract](/how-abstract-works/system-contracts/list-of-system-contracts.mdx#l1messenger)
    for it to begin sending data to Ethereum about the transactions that were processed.
 
 ## BootloaderUtilities System Contract

--- a/portal/overview.mdx
+++ b/portal/overview.mdx
@@ -5,7 +5,7 @@ description: "Discover the Abstract Portal - your gateway to onchain discovery."
 ---
 
 The [Portal](https://abs.xyz) is the homepage of consumer crypto. Users can manage their
-[Abstract Global Wallet](/abstract-global-wallet/overview), earn XP and badges, and discover
+[Abstract Global Wallet](/abstract-global-wallet/overview.mdx), earn XP and badges, and discover
 the top apps & creators in the ecosystem.
 
 <Card title="Visit Portal" icon="person-to-portal" href="https://abs.xyz">

--- a/what-is-abstract.mdx
+++ b/what-is-abstract.mdx
@@ -14,7 +14,7 @@ and verifying batches of transactions on Ethereum using [(ZK) proofs](https://et
 
 Abstract is [EVM](https://ethereum.org/en/developers/docs/evm/) compatible, meaning it looks and feels like
 Ethereum, but with lower gas fees and higher transaction throughput. Most existing smart contracts built for Ethereum will work
-out of the box on Abstract ([with some differences](/how-abstract-works/evm-differences/overview)),
+out of the box on Abstract ([with some differences](/how-abstract-works/evm-differences/overview.mdx)),
 meaning developers can easily port applications to Abstract with minimal changes.
 
 ## Start using Abstract


### PR DESCRIPTION
Updated documentation links by adding the .mdx extension to ensure they are functional and point to the correct pages, as the previous links were returning a 404 error. 