### PR TITLE
Fix broken link on the website

### DIFF
--- a/how-abstract-works/evm-differences/precompiles.mdx
+++ b/how-abstract-works/evm-differences/precompiles.mdx
@@ -42,7 +42,7 @@ Emulates the EVM&rsquo;s [keccak256](https://www.evm.codes/#20?fork=cancun) opco
 <Card
   title="KECCAK256 source code"
   icon="github"
-  href="https://github.com/matter-labs/era-contracts/tree/main/system-contracts/contracts/precompiles/KECCAK256.yul"
+  href="https://github.com/matter-labs/era-contracts/tree/main/system-contracts/contracts/precompiles/Keccak256.yul"
 >
   View the source code for the KECCAK256 precompile on GitHub.
 </Card>


### PR DESCRIPTION
### Updated documentation link, as the previous link were returning a 404 error.
**Before:**
![image](https://github.com/user-attachments/assets/8b1db58d-0ee9-4930-a716-0f2faceeed9c)
![image](https://github.com/user-attachments/assets/0f4a9e07-b1c8-4d9c-9990-ebbb5eacc932)
**After:**
![image](https://github.com/user-attachments/assets/a09db938-f520-47aa-a809-dab8fcc0dafd)
