### PR TITLE
Update revokeSession.mdx

### DIFF
--- a/abstract-global-wallet/agw-client/session-keys/revokeSessions.mdx
+++ b/abstract-global-wallet/agw-client/session-keys/revokeSessions.mdx
@@ -12,7 +12,7 @@ This allows you to invalidate existing session keys, preventing them from being 
 Revoke session(s) by providing either:
 
 - The session configuration object(s) (see [parameters](#parameters)).
-- The transaction hash(es) returned by [createSession](/abstract-global-wallet/agw-client/session-keys/createSession).
+- The session hash(es) returned by [getSessionHash()](https://github.com/Abstract-Foundation/agw-sdk/blob/ea8db618788c6e93100efae7f475da6f4f281aeb/packages/agw-client/src/sessions.ts#L213).
 
 ```tsx
 import { useAbstractClient } from "@abstract-foundation/agw-react";


### PR DESCRIPTION
Using the "The transaction hash(es) returned by [createSession]" doesn't work, the hash from session is not equal to transaction created hash. 

So I updated the text to save 30 minutes of confusion for the next dev.