### PR TITLE
Addition to forge initialization

### DIFF
--- a/build-on-abstract/smart-contracts/foundry.mdx
+++ b/build-on-abstract/smart-contracts/foundry.mdx
@@ -81,7 +81,8 @@ You may need to restart your terminal session after installation to continue.
 Create a new project with `forge` and change directory into the project.
 
 ```bash
-forge init my-abstract-project && cd my-abstract-project
+forge init my-abstract-project && cd my-abstract-project # Note: Creates a new directory and navigates to it
+forge init --force # Note: Initializes forge in the current directory
 ```
 
 ## 3. Modify Foundry configuration


### PR DESCRIPTION
It is not always convenient to create a new directory, sometimes a person already has one but doesn't know how to initialize forge in it, for this you need the --force argument.