### PR TITLE
Docs Update: Renaning "WalletConnect" to "Reown" to reflect the correct entity name

### DIFF
--- a/abstract-global-wallet/agw-react/integrating-with-reown.mdx
+++ b/abstract-global-wallet/agw-react/integrating-with-reown.mdx
@@ -1,17 +1,16 @@
 ---
-title: "WalletConnect"
-description: "Learn how to integrate Abstract Global Wallet with WalletConnect."
+title: "Reown"
+description: "Learn how to integrate Abstract Global Wallet with Reown."
 ---
 
-Users can connect to AGW via WalletConnect and approve transactions from within the [Abstract Portal](https://portal.abs.xyz/profile).
+Users can connect to AGW via Reown (prev. known as WalletConnect) and approve transactions from within the [Abstract Portal](https://portal.abs.xyz/profile).
 
 <Card
-  title="AGW + WalletConnect Example Repo"
+  title="AGW + Reown Example Repo"
   icon="github"
   href="https://github.com/Abstract-Foundation/examples/tree/main/agw-walletconnect-nextjs"
 >
-  Use our example repo to quickly get started with WalletConnect (AppKit) and
-  AGW.
+  Use our example repo to quickly get started with Reown AppKit and AGW.
 </Card>
 
 ## Installation

--- a/docs.json
+++ b/docs.json
@@ -157,7 +157,7 @@
               "abstract-global-wallet/agw-react/integrating-with-dynamic",
               "abstract-global-wallet/agw-react/integrating-with-privy",
               "abstract-global-wallet/agw-react/integrating-with-rainbowkit",
-              "abstract-global-wallet/agw-react/integrating-with-walletconnect",
+              "abstract-global-wallet/agw-react/integrating-with-reown",
               "abstract-global-wallet/agw-react/integrating-with-thirdweb"
             ]
           },

--- a/docs.json
+++ b/docs.json
@@ -296,6 +296,10 @@
     {
       "source": "build-on-abstract/smart-contracts/foundry",
       "destination": "/build-on-abstract/smart-contracts/foundry/get-started"
+    },
+    {
+      "source": "/abstract-global-wallet/agw-react/integrating-with-walletconnect",
+      "destination": "/abstract-global-wallet/agw-react/integrating-with-reown"
     }
   ]
 }


### PR DESCRIPTION
## Description

WalletConnect Inc. was rebranded to Reown. Consequently, this PR updates the existing AGW integration guide for Reown to remove references to "WalletConnect" and replace them with "Reown". 

## Tests

Tested locally using Mintlify CLI.