### PR TITLE
Update documentation link in testing-contracts.mdx

### DIFF
--- a/build-on-abstract/smart-contracts/foundry/testing-contracts.mdx
+++ b/build-on-abstract/smart-contracts/foundry/testing-contracts.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Testing Contracts"
 description: "Learn how to test your smart contracts using Foundry."
 ---
 
-Verify your smart contracts work as intended before you deploy them by writing [tests](https://foundry-book.zksync.io/forge/testing/).
+Verify your smart contracts work as intended before you deploy them by writing [tests](https://foundry-book.zksync.io/forge/tests).
 
 ## Testing Smart Contracts
 


### PR DESCRIPTION
File: build-on-abstract/smart-contracts/foundry/testing-contracts.mdx

Updated URL:
- /forge/testing/
+ /forge/tests
Reason:
Replaced outdated/broken link with the correct one to improve documentation accuracy.