### PR TITLE
Fix broken link in Update best-practices.mdx

### DIFF
--- a/how-abstract-works/evm-differences/best-practices.mdx
+++ b/how-abstract-works/evm-differences/best-practices.mdx
@@ -41,7 +41,7 @@ Some additional changes may be required in your contract. [Learn more in this se
 
 [EIP-712](https://eips.ethereum.org/EIPS/eip-712) transactions have a `gasPerPubdataByte`
 field that can be set to control the amount of gas that is charged for each byte of data sent to L1
-(see [transaction lifecycle](/how-abstract-works/architecture/transaction-lifecycle)). [Learn more ↗](https://docs.zksync.io/build/developer-reference/era-contracts/pubdata-post-4844).
+(see [transaction lifecycle](/how-abstract-works/architecture/transaction-lifecycle)). [Learn more ↗](https://docs.zksync.io/zksync-protocol/rollup/fee-model/how-we-charge-for-pubdata.
 
 When calculating how much gas is remaining using `gasleft()`, consider that the
 `gasPerPubdataByte` also needs to be accounted for.


### PR DESCRIPTION
This PR updates the outdated link in the Best Practices page of the Abstract documentation. Replaced the dead link: https://docs.zksync.io/build/developer-reference/era-contracts/pubdata-post-4844 To new: https://docs.zksync.io/zksync-protocol/rollup/fee-model/how-we-charge-for-pubdata

This new link correctly describes how gasPerPubdataByte works in zkSync and matches the context of EIP-712 transactions.

Why:
The original URL leads to a 404 page. Keeping links up to date helps ensure developers have access to relevant information and reduces confusion when reading the documentation.