### PR TITLE
Add ethfaucet.com faucet to faucets section

### DIFF
--- a/tooling/faucets.mdx
+++ b/tooling/faucets.mdx
@@ -13,11 +13,12 @@ Abstract testnet.
 
 ## Abstract Testnet Faucets
 
-| Name                                                                    | Requires Signup |
-| ----------------------------------------------------------------------- | --------------- |
-| [Alchemy faucet](https://www.alchemy.com/faucets/abstract-testnet)      | No              |
-| [Triangle faucet](https://faucet.triangleplatform.com/abstract/testnet) | No              |
-| [Thirdweb faucet](https://thirdweb.com/abstract-testnet)                | Yes             |
+| Name                                                                              | Requires Signup |
+| --------------------------------------------------------------------------------- | --------------- |
+| [Alchemy faucet](https://www.alchemy.com/faucets/abstract-testnet)                | No              |
+| [Triangle faucet](https://faucet.triangleplatform.com/abstract/testnet)           | No              |
+| [Thirdweb faucet](https://thirdweb.com/abstract-testnet)                          | Yes             |
+| [ethfaucet.com faucet](https://ethfaucet.com?utm_source=abs_docs&utm_medium=docs) | No               |
 
 ## L1 Sepolia Faucets
 
@@ -30,5 +31,6 @@ Abstract testnet.
 | [Infura Sepolia faucet](https://www.infura.io/faucet/sepolia)                                        | Yes             | -                                       |
 | [Chainstack Sepolia faucet](https://faucet.chainstack.com/sepolia-testnet-faucet)                    | Yes             | -                                       |
 | [Alchemy Sepolia faucet](https://www.alchemy.com/faucets/ethereum-sepolia)                           | No              | 0.001 mainnet ETH                       |
+| [ethfaucet.com faucet](https://ethfaucet.com?utm_source=abs_docs&utm_medium=docs)                    | No              | BringID verification                    |
 
 Use a [bridge](/tooling/bridges) to move Sepolia ETH to the Abstract testnet.


### PR DESCRIPTION
Description
Adding a new faucet (ethfaucet.com) to the docs.
ethfaucet.com provides developers with 0.1 Abstract testnet ETH for free, claimable once every 24 hours.

Additional context
ethfaucet.com is maintained and powered by BringID. BringID is a proof-of-humanity solution from web accounts helping crypto apps to resist sybil attacks and bot abuse.