### PR TITLE
Add session key mainnet warning to overview page

### DIFF
--- a/abstract-global-wallet/session-keys/overview.mdx
+++ b/abstract-global-wallet/session-keys/overview.mdx
@@ -8,6 +8,10 @@ Session keys are temporary keys that are approved to execute a pre-defined set o
 
 They unlock seamless user experiences by executing transactions behind the scenes without interrupting the user with popups; powerful for games, mobile apps, and more.
 
+<Warning>
+  Session keys are permissionless on **testnet**, however, **mainnet** requires applications to pass a security review before being added to the [Session Key Policy Registry](/abstract-global-wallet/session-keys/going-to-production#session-key-policy-registry). See [Going to Production](/abstract-global-wallet/session-keys/going-to-production) for details.
+</Warning>
+
 ## How session keys work
 
 Applications can prompt users to approve the creation of a session key for their Abstract Global Wallet.


### PR DESCRIPTION
## Summary
- Adds a prominent `<Warning>` callout at the top of the session keys overview page
- Warns developers that mainnet requires a security review before session keys can be used
- Links to the Session Key Policy Registry and Going to Production documentation

## Test plan
- [ ] Verify the warning renders correctly on the overview page
- [ ] Confirm links navigate to the correct sections