### PR TITLE
Fix redirect source path for foundry docs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -307,7 +307,7 @@
       "destination": "/build-on-abstract/smart-contracts/hardhat/get-started"
     },
     {
-      "source": "build-on-abstract/smart-contracts/foundry",
+      "source": "/build-on-abstract/smart-contracts/foundry",
       "destination": "/build-on-abstract/smart-contracts/foundry/get-started"
     },
     {


### PR DESCRIPTION
What: added missing leading / in redirect source
Why: ensures redirect matches consistently