### PR TITLE
Add gitignore for OS-generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## What changed

- Added a `.gitignore` file at the repository root.
- Ignored common OS-generated files:
  - `.DS_Store` (macOS)
  - `Thumbs.db` (Windows)

## Why

This prevents accidental commits of system-generated binary files that are not part of the codebase.

It also avoids issues like committing `.DS_Store` files, which cannot be meaningfully read or reviewed as text and previously caused unnecessary noise in the repository.
