### PR TITLE
Add Orbiter bridge to ecosystem bridges

### DIFF
--- a/ecosystem/bridges.mdx
+++ b/ecosystem/bridges.mdx
@@ -9,4 +9,5 @@ description: "Move funds from other chains to Abstract and vice versa."
   <Card title="Jumper" icon="link" href="https://jumper.exchange/" />
   <Card title="Symbiosis" icon="link" href="https://symbiosis.finance/" />
   <Card title="thirdweb" icon="link" href="https://thirdweb.com/bridge?chainId=2741" />
+  <Card title="Orbiter" icon="link" href="https://orbiter.finance/" />
 </CardGroup>


### PR DESCRIPTION
Added Orbiter (Abstract support) as a bridge option for the Abstract network. Orbiter enables fast and low-cost transfers, making it a convenient solution for moving assets to and from Abstract.