### PR TITLE
fix(docs): remove duplicate Mobula entry

### DIFF
--- a/ecosystem/indexers.mdx
+++ b/ecosystem/indexers.mdx
@@ -21,12 +21,7 @@ description: "View the indexers and APIs available on Abstract."
     icon="link"
     href="https://docs.reservoir.tools/reference/what-is-reservoir"
   />
-<Card title="Mobula" icon="link" href="https://docs.mobula.io/introduction" />
-  <Card
-    title="Mobula"
-    icon="link"
-    href="https://docs.mobula.io/introduction"
-  />
+  <Card title="Mobula" icon="link" href="https://docs.mobula.io/introduction" />
   <Card title="SQD" icon="link" href="https://docs.sqd.ai/" />
   <Card title="Zapper" icon="link" href="https://protocol.zapper.xyz/chains/abstract" />
 </CardGroup>


### PR DESCRIPTION
- Removed the duplicated Mobula card from the Data & Indexing section.
- Verified against the official docs website (docs.abs.xyz/ecosystem/indexers), the duplication exists with identical cards and links.