### PR TITLE
docs: Add security requirements section for third-party bridges

### DIFF
--- a/tooling/bridges.mdx
+++ b/tooling/bridges.mdx
@@ -52,6 +52,8 @@ Third-party bridges introduce security risks beyond Abstract's native bridge. Ke
 1. **Smart contract risk:** bridge code may contain vulnerabilities that could lead to loss of funds.
 2. **Operational Risk:** Bridge downtime or Team actions can freeze funds unexpectedly.
 3. **Liquidity:** Insufficient liquidity can cause failed transactions or slippage.
+
+The Abstract team is not responsible for any problems, losses, or security incidents arising from the use of third-party bridges.
 </Warning>
 
 <Card title="View Third-party Bridges" icon="bridge" href="/ecosystem/bridges">

--- a/tooling/bridges.mdx
+++ b/tooling/bridges.mdx
@@ -45,6 +45,15 @@ to move assets from other chains to Abstract and vice versa.
 These bridges offer alternative routes that are typically faster and cheaper than the native bridge,
 however come with different **security risks**.
 
+<Warning>
+**Security Requirements**
+
+Third-party bridges introduce security risks beyond Abstract's native bridge. Key considerations:
+1. **Smart contract risk:** bridge code may contain vulnerabilities that could lead to loss of funds.
+2. **Operational Risk:** Bridge downtime or Team actions can freeze funds unexpectedly.
+3. **Liquidity:** Insufficient liquidity can cause failed transactions or slippage.
+</Warning>
+
 <Card title="View Third-party Bridges" icon="bridge" href="/ecosystem/bridges">
   Use third-party bridges to move assets between other chains and Abstract.
 </Card>


### PR DESCRIPTION
**Motivation:** Users often lack adequate understanding of third-party bridge security risks. Many incorrectly attribute responsibility for bridge-related incidents to the ecosystem team rather than the bridge operators, creating confusion about liability boundaries.

**Solution:** Add a structured description of the key risks of using third-party bridges. Also supplement this with a description that clearly delineates the responsibilities between the bridge teams and the Abstract team.
