### PR TITLE
docs: fix broken and outdated documentation links

### DIFF
--- a/build-on-abstract/smart-contracts/foundry/get-started.mdx
+++ b/build-on-abstract/smart-contracts/foundry/get-started.mdx
@@ -132,7 +132,7 @@ contract Counter {
 
 ## 5. Compile the smart contract
 
-Use the [zksolc compiler](https://docs.zksync.io/zk-stack/components/compiler/toolchain/solidity)
+Use the [zksolc compiler](https://docs.zksync.io/zksync-protocol/era-vm/compiler/toolchain)
 (installed in the above steps) to compile smart contracts for Abstract:
 
 ```bash
@@ -145,7 +145,7 @@ You should now see the compiled smart contracts in the generated `zkout` directo
 
 <Steps>
   <Step title="Add your private key" icon="key">
-    Create a new [wallet keystore](https://book.getfoundry.sh/reference/cast/cast-wallet-import).
+    Create a new [wallet keystore](https://getfoundry.sh/cast/reference/wallet/import).
 
     ```bash
     cast wallet import myKeystore --interactive

--- a/build-on-abstract/smart-contracts/foundry/testing-contracts.mdx
+++ b/build-on-abstract/smart-contracts/foundry/testing-contracts.mdx
@@ -119,7 +119,7 @@ Abstract's underlying ZKsync VM provides additional cheatcodes for testing Abstr
 
 Running your tests against a fork of Abstract testnet or mainnet allows you to test your contracts in a real environment before deploying to Abstract.
 
-This is especially useful for testing contracts that interact with other contracts on Abstract such as those listed on the [Deployed Contracts](https://docs.abstract.xyz/tooling/deployed-contracts) page.
+This is especially useful for testing contracts that interact with other contracts on Abstract such as those listed on the [Deployed Contracts](https://docs.abs.xyz/tooling/deployed-contracts) page.
 
 To run your tests against a fork of Abstract testnet or mainnet, you can use the following command:
 
@@ -137,7 +137,7 @@ forge test --zksync --fork-url https://api.mainnet.abs.xyz
 
 ## Local Node Testing
 
-[Anvil-zksync](https://foundry-book.zksync.io/anvil-zksync/) comes installed with Foundry, and is a tool that allows you
+[Anvil-zksync](https://foundry-book.zksync.io/reference/anvil-zksync/README#anvil-namespace) comes installed with Foundry, and is a tool that allows you
 to instantiate a local node for testing purposes.
 
 Run the following command to start the local node:

--- a/build-on-abstract/smart-contracts/hardhat/get-started.mdx
+++ b/build-on-abstract/smart-contracts/hardhat/get-started.mdx
@@ -163,7 +163,7 @@ Clear any existing artifacts:
 npx hardhat clean
 ```
 
-Use the [zksolc compiler](https://docs.zksync.io/zk-stack/components/compiler/toolchain/solidity)
+Use the [zksolc compiler]()
 (installed in the above steps) to compile smart contracts for Abstract:
 
 <CodeGroup>

--- a/how-abstract-works/architecture/components/prover-and-verifier.mdx
+++ b/how-abstract-works/architecture/components/prover-and-verifier.mdx
@@ -50,7 +50,7 @@ The proof generation process is composed of three main steps:
     The ZK-proving circuit iterates over the entire transaction batch,
     verifying the sequence of updates that result in a final state root after the last transaction is executed.
 
-    Abstract uses [Boojum](https://docs.zksync.io/zk-stack/components/prover/boojum-gadgets)
+    Abstract uses [Boojum](https://docs.zksync.io/zksync-protocol/era-vm/circuits/boojum-gadgets)
     to prove and verify the circuit functionality, along with operating the backend components necessary for circuit construction.
 
     <CardGroup cols={2}>

--- a/how-abstract-works/evm-differences/overview.mdx
+++ b/how-abstract-works/evm-differences/overview.mdx
@@ -6,7 +6,7 @@ description: "Learn the differences between Abstract and Ethereum."
 
 While Abstract is EVM compatible and you can use familiar development
 tools from the Ethereum ecosystem, the bytecode that Abstract&rsquo;s VM
-(the [ZKsync VM](https://docs.zksync.io/build/developer-reference/era-vm)) understands
+(the [ZKsync VM](https://docs.zksync.io/zksync-protocol/era-vm)) understands
 is different than what Ethereum&rsquo;s [EVM](https://ethereum.org/en/developers/docs/evm/) understands.
 
 These differences exist to both optimize the VM to perform efficiently with ZK proofs

--- a/how-abstract-works/system-contracts/bootloader.mdx
+++ b/how-abstract-works/system-contracts/bootloader.mdx
@@ -10,7 +10,7 @@ The bootloader system contract plays several vital roles on Abstract, responsibl
 - Constructing new blocks for the L2
 
 The bootloader processes transactions in batches that it
-receives from the [VM](https://docs.zksync.io/build/developer-reference/era-vm) and puts
+receives from the [VM](https://docs.zksync.io/zksync-protocol/era-vm) and puts
 them all through the flow outlined in the
 [transaction flow](/how-abstract-works/native-account-abstraction/transaction-flow) section.
 
@@ -25,7 +25,7 @@ them all through the flow outlined in the
   <Card
     title="ZK Stack Docs - Bootloader"
     icon="file-contract"
-    href="https://docs.zksync.io/zk-stack/components/zksync-evm/bootloader#bootloader"
+    href="https://docs.zksync.io/zksync-protocol/zksyncos/bootloader"
   >
     View in-depth documentation on the Bootloader.
   </Card>


### PR DESCRIPTION
 Summary
Updates broken and outdated external links across the Abstract docs so they point to current URLs.

## Changes
-Foundry (get-started):** Updated zksolc compiler and Foundry wallet keystore links to current zkSync / getfoundry.sh URLs.
-Foundry (testing):** Corrected Deployed Contracts link (`docs.abstract.xyz` → `docs.abs.xyz`) and Anvil-zksync reference URL.
-Hardhat (get-started):** Adjusted zksolc compiler reference (link may need a final target if the current zkSync URL is still in flux).
-How Abstract works:** Updated zkSync-era doc links (VM, Boojum, bootloader) from old paths to `docs.zksync.io/zksync--protocol/...` and related structure.

Files touched
- `build-on-abstract/smart-contracts/foundry/get-started.mdx`
- `build-on-abstract/smart-contracts/foundry/testing-contracts.mdx`
- `build-on-abstract/smart-contracts/hardhat/get-started.mdx`
- `how-abstract-works/architecture/components/prover-and-verifier.mdx`
- `how-abstract-works/evm-differences/overview.mdx`
- `how-abstract-works/system-contracts/bootloader.mdx`

How did you Tested?
By Manually Tested, now all links working properly.