### PR TITLE
fix: remove duplicate Mobula entry from indexers.mdx

### DIFF
--- a/ecosystem/indexers.mdx
+++ b/ecosystem/indexers.mdx
@@ -21,7 +21,6 @@ description: "View the indexers and APIs available on Abstract."
     icon="link"
     href="https://docs.reservoir.tools/reference/what-is-reservoir"
   />
-<Card title="Mobula" icon="link" href="https://docs.mobula.io/introduction" />
   <Card
     title="Mobula"
     icon="link"


### PR DESCRIPTION
### Description
This PR fixes a small issue in the `indexers.mdx` file where the **Mobula** card was listed twice consecutively. I have removed the duplicate entry to clean up the documentation.

### Changes
- Removed duplicate `<Card>` component for Mobula in `abstract-docs/indexers.mdx`.