### PR TITLE
Replacing the API key in the example.

### DIFF
--- a/cookbook/random-number-generation.mdx
+++ b/cookbook/random-number-generation.mdx
@@ -190,7 +190,7 @@ Test your game contract behaviour with Absmate's mock contracts.
     --verify \
     --verifier etherscan \
     --verifier-url https://api-sepolia.abscan.org/api \
-    --etherscan-api-key TACK2D1RGYX9U7MC31SZWWQ7FCWRYQ96AD
+    --etherscan-api-key <YOUR_API_KEY>
   ```
   </Step>
 


### PR DESCRIPTION
We replaced the API key example in the documentation with `<YOUR_API_KEY>`. Now, when working with the guide, developers will substitute their current key from Etherscan.