### PR TITLE
docs: add ERC-8004 addresses to deployed contracts page

### DIFF
--- a/tooling/deployed-contracts.mdx
+++ b/tooling/deployed-contracts.mdx
@@ -11,6 +11,13 @@ description: "Discover a list of commonly used contracts deployed on Abstract."
 | USDC  | `0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1` | `0xe4C7fBB0a626ed208021ccabA6Be1566905E2dFc` |
 | USDT  | `0x0709F39376dEEe2A2dfC94A58EdEb2Eb9DF012bD` | -                                            |
 
+## ERC-8004
+
+| Contract Type      | Mainnet                                      | Testnet |
+| ------------------ | -------------------------------------------- | ------- |
+| IdentityRegistry   | `0x8004A169FB4a3325136EB29fA0ceB6D2e539a432` | -       |
+| ReputationRegistry | `0x8004BAa17C55a88189AE136b182e5fdA19dE9b63` | -       |
+
 ## NFT Markets
 
 | Contract Type      | Mainnet                                      | Testnet                                      |


### PR DESCRIPTION
## Summary
- add an `ERC-8004` section to the deployed contracts page
- add `IdentityRegistry` mainnet address
- add `ReputationRegistry` mainnet address

## Verification
- `python -m json.tool docs.json > /dev/null`
- `mintlify broken-links`
- `mintlify openapi-check api-reference/openapi.json`
