### PR TITLE
fix: references in the cards

### DIFF
--- a/how-abstract-works/evm-differences/overview.mdx
+++ b/how-abstract-works/evm-differences/overview.mdx
@@ -68,21 +68,21 @@ Learn the nuances of other differences between Abstract and Ethereum.
   <Card
     title="Gas fees"
     icon="gas-pump"
-    href="/how-abstract-works/evm-differences/best-practices"
+    href="/how-abstract-works/evm-differences/gas-fees"
   >
     Learn how gas fees and gas refunds work with the bootloader on Abstract.
   </Card>
   <Card
     title="Nonces"
     icon="up"
-    href="/how-abstract-works/evm-differences/contract-deployment"
+    href="/how-abstract-works/evm-differences/nonces"
   >
     Explore how nonces are stored on Abstract&rsquo;s smart contract accounts.
   </Card>
   <Card
     title="Libraries"
     icon="file-import"
-    href="/how-abstract-works/evm-differences/contract-deployment"
+    href="/how-abstract-works/evm-differences/libraries"
   >
     Learn how the compiler handles libraries on Abstract.
   </Card>


### PR DESCRIPTION
In the documentation, in the section how-abstract-works/evm-differences/overview.mdx, three links in the cards do not correspond to their names:
- `gas-fees > best-practices`
- `nonces > contract-deployment`
- `libraries > contract-deployment`

I changed them to match their names:
- `gas-fees > gas-fees`
- `nonces > nonces`
- `libraries > libraries`

<img width="732" height="378" alt="image" src="https://github.com/user-attachments/assets/da2c6a03-2499-49a5-85df-2f87bddd002b" />
