### PR TITLE
Update gas fees docs description

### DIFF
--- a/how-abstract-works/evm-differences/gas-fees.mdx
+++ b/how-abstract-works/evm-differences/gas-fees.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Gas Fees"
-description: "Learn how Abstract differs from Ethereum's EVM opcodes."
+description: "Learn how gas fees and gas refunds work on Abstract."
 ---
 
 Abstract&rsquo;s gas fees depend on the fluctuating


### PR DESCRIPTION
In the previous description:
`“Learn how Abstract differs from Ethereum's EVM opcodes.”`
differences in EVM opcodes were mentioned, while the article mainly explains:
- Abstract’s gas fee model (offchain + onchain components)
- Batch cost distribution mechanics
- Pubdata pricing
- Fair fee calculation
- Gas refund mechanism

This is clearly an error in the description.

Updated description:
`"Learn how gas fees and gas refunds work on Abstract."`

This more accurately reflects the scope and technical focus of the page.