### PR TITLE
Fix incomplete Usage example: add return button to SendTransaction component

### DIFF
--- a/abstract-global-wallet/agw-client/actions/sendTransaction.mdx
+++ b/abstract-global-wallet/agw-client/actions/sendTransaction.mdx
@@ -25,6 +25,7 @@ export default function SendTransaction() {
     });
   }
 
+  return (<button onClick={sendTransaction}>Send Transaction</button>);
 }
 ```
 


### PR DESCRIPTION
Fix incomplete Usage example: add return button to `SendTransaction` component

Adds missing return with a button to make the `SendTransaction` example self-contained and consistent with other documentation examples (e.g. [this example](https://github.com/Meesut0/abstract-docs/blob/helloworld/abstract-global-wallet/agw-react/native-integration.mdx#4-use-the-wallet))