### PR TITLE
fix: resolve invalid hex prefix in openapi.json example

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -5137,7 +5137,7 @@
                           },
                           "execute": {
                             "contractAddress": "0x5155704bb41fde152ad3e1ae402e8e8b9ba335d3",
-                            "calldata": "0fa0x5155704bb41fde152ad3e1ae402e8e8b9ba335d3",
+                            "calldata": "0x5155704bb41fde152ad3e1ae402e8e8b9ba335d3",
                             "value": "0x0",
                             "factoryDeps": null
                           },


### PR DESCRIPTION
### Description
While auditing the API specification, I identified an invalid hex string format in the `openapi.json` file.

**The Issue:**
On line 5140, the `calldata` example was incorrectly prefixed with `0fa0x...` instead of the standard `0x...`. This is not a valid hex format and would cause "invalid hex string" errors for developers trying to use the example values in automated tools or manual testing.

**The Fix:**
- Corrected the `calldata` value in `./api-reference/openapi.json` by removing the erroneous `0fa` prefix.

### Impact
Ensures the OpenAPI specification remains technically accurate and prevents integration errors for developers copying example values.