### PR TITLE
Fix: add return button to SignTransaction component

### DIFF
--- a/abstract-global-wallet/agw-client/actions/signTransaction.mdx
+++ b/abstract-global-wallet/agw-client/actions/signTransaction.mdx
@@ -23,6 +23,8 @@ export default function SignTransaction() {
       data: "0x69",
     });
   }
+
+  return (<button onClick={signTransaction}>Sign Transaction</button>);
 }
 ```
 


### PR DESCRIPTION
Fixed the `SignTransaction` example in
`abstract-global-wallet/agw-client/actions/signTransaction.mdx`.

The component previously declared a React function but did not return any JSX, making the example incomplete and not directly usable as a copy-paste snippet.

This change adds a simple `<button>` element that calls `signTransaction`, making the example consistent with the `SendTransaction` example and other examples mentioned in PR: #198.