### PR TITLE
Update URL in `Data & Indexing`

### DIFF
--- a/ecosystem/indexers.mdx
+++ b/ecosystem/indexers.mdx
@@ -15,7 +15,7 @@ description: "View the indexers and APIs available on Abstract."
     icon="link"
     href="https://docs.goldsky.com/chains/abstract"
   />
-  <Card title="The Graph" icon="link" href="https://thegraph.com/docs/" />
+  <Card title="The Graph" icon="link" href="https://thegraph.com/docs/en/supported-networks/abstract/" />
   <Card
     title="Reservoir"
     icon="link"


### PR DESCRIPTION
Previously, the link led to The Graph's website, but I added `supported-networks/abstract/` so that clicking the link would take you directly to the **Abstract** network. A small change for convenience!