### PR TITLE
Add AI agents docs section

### DIFF
--- a/abstract-global-wallet/overview.mdx
+++ b/abstract-global-wallet/overview.mdx
@@ -21,7 +21,7 @@ AGW provides a seamless and secure way to onboard users, in which
 they sign up once using familiar login methods (such as email, social accounts,
 passkeys and more), and can then use this account to interact with _any_ application on Abstract.
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
   <Card
     title="Get Started with AGW"
     icon="rocket"
@@ -35,6 +35,13 @@ passkeys and more), and can then use this account to interact with _any_ applica
     href="/abstract-global-wallet/architecture"
   >
     Learn more about how Abstract Global Wallet works under the hood.
+  </Card>
+  <Card
+    title="AGW for AI Agents"
+    icon="terminal"
+    href="/ai-agents/wallet-access/agw-cli-overview"
+  >
+    Use AGW CLI and MCP when an agent needs controlled access to an AGW.
   </Card>
 </CardGroup>
 

--- a/ai-agents/build-paths.mdx
+++ b/ai-agents/build-paths.mdx
@@ -1,0 +1,28 @@
+---
+title: "Build Paths"
+description: "Choose the right starting point for your Abstract agent workflow."
+---
+
+This section is organized around workflows, not frameworks.
+
+## I want my agent to pay for APIs
+
+- If you want straightforward pay-per-request billing with a public facilitator, start with [`x402`](/ai-agents/payments/x402/overview).
+- If you want HTTP-native payments with a choice between one-off charge and channel-based session payments, start with [`MPP`](/ai-agents/payments/mpp/overview).
+
+## I want to charge other agents
+
+- Use [`Accept x402 Payments`](/ai-agents/payments/x402/accepting-payments) if you want the simplest integration path today.
+- Use [`MPP Charge Payments`](/ai-agents/payments/mpp/charge-payments) for one-off signed authorizations.
+- Use [`MPP Session Payments`](/ai-agents/payments/mpp/session-payments) if clients will make repeated requests and you want lower per-request overhead.
+
+## I want an agent to control an AGW
+
+- Start with [`AGW CLI Overview`](/ai-agents/wallet-access/agw-cli-overview).
+- Then follow [`Install and Authenticate`](/ai-agents/wallet-access/install-and-authenticate).
+- If your host supports MCP, continue to [`Run AGW as MCP`](/ai-agents/wallet-access/run-as-mcp).
+
+## I want my coding agent to understand Abstract docs
+
+- Use [`Agent Resources`](/ai-agents/resources/overview) for docs MCP and machine-readable docs formats.
+- Use [`SKILL.MD`](/ai-agents/resources/skill-md) when the agent needs workflows, decision tables, and gotchas instead of raw page text.

--- a/ai-agents/overview.mdx
+++ b/ai-agents/overview.mdx
@@ -1,0 +1,79 @@
+---
+title: "AI Agents"
+description: "Build agents on Abstract that can pay for services, control wallets, and use docs-native tooling."
+---
+
+Build AI agents on Abstract that can pay for APIs, accept payments from other agents, and operate through Abstract Global Wallet.
+
+Abstract's agent stack has four main pieces:
+
+- `x402` for pay-per-request HTTP payments
+- `MPP` for HTTP-native charge and session payments
+- `AGW CLI` and `MCP` for agent wallet access
+- `llms.txt`, `llms-full.txt`, `SKILL.MD`, and docs MCP for coding-agent context
+
+## What you can build
+
+- An agent that pays for premium APIs on demand
+- A paid API that charges other agents per request
+- A wallet-enabled operator that reads balances, previews transactions, and executes approved actions
+- A coding agent that understands Abstract docs and uses the right SDKs and network settings
+
+## Choose your path
+
+<CardGroup cols={2}>
+  <Card title="Payments" icon="credit-card" href="/ai-agents/payments/x402/overview">
+    Start with x402 or MPP if your agent needs to pay or get paid.
+  </Card>
+  <Card title="Wallet Access" icon="wallet" href="/ai-agents/wallet-access/agw-cli-overview">
+    Start with AGW CLI if your agent needs controlled wallet access.
+  </Card>
+  <Card title="Build Paths" icon="route" href="/ai-agents/build-paths">
+    Pick the shortest route based on the workflow you actually need.
+  </Card>
+  <Card title="Agent Resources" icon="robot" href="/ai-agents/resources/overview">
+    Use docs MCP, llms.txt, and SKILL.MD to give coding agents Abstract context.
+  </Card>
+</CardGroup>
+
+## How the pieces fit together
+
+1. Choose a payment model:
+   `x402` for simple 402-based pay-per-request flows, or `MPP` for HTTP-native charge and session payments.
+2. Choose a wallet path:
+   `AGW CLI` if the agent should operate through Abstract Global Wallet with preview-first writes and policy-scoped permissions.
+3. Add docs-native context:
+   point coding agents at the docs MCP endpoint or the machine-readable documentation files.
+
+## Payments for agents
+
+<CardGroup cols={2}>
+  <Card title="x402" icon="bolt" href="/ai-agents/payments/x402/overview">
+    Accept and make HTTP payments on Abstract using the public facilitator.
+  </Card>
+  <Card title="MPP" icon="coins" href="/ai-agents/payments/mpp/overview">
+    Use charge payments for one-off requests or session payments for repeated micro-payments.
+  </Card>
+</CardGroup>
+
+## Wallet access for agents
+
+<CardGroup cols={2}>
+  <Card title="AGW CLI Overview" icon="terminal" href="/ai-agents/wallet-access/agw-cli-overview">
+    Understand the command surface, delegated signer model, and MCP support.
+  </Card>
+  <Card title="Run AGW as MCP" icon="plug" href="/ai-agents/wallet-access/run-as-mcp">
+    Expose wallet, transaction, app, and Portal actions to MCP-capable hosts.
+  </Card>
+</CardGroup>
+
+## Resources for coding agents
+
+<CardGroup cols={2}>
+  <Card title="Agent Resources" icon="book-open" href="/ai-agents/resources/overview">
+    Start here for docs MCP, llms.txt, llms-full.txt, and SKILL.MD.
+  </Card>
+  <Card title="Contracts and Endpoints" icon="book" href="/ai-agents/resources/contracts-and-endpoints">
+    Keep the key chain IDs, token addresses, facilitators, and agent endpoints in one place.
+  </Card>
+</CardGroup>

--- a/ai-agents/payments/mpp/charge-payments.mdx
+++ b/ai-agents/payments/mpp/charge-payments.mdx
@@ -1,0 +1,75 @@
+---
+title: "MPP Charge Payments"
+description: "Use MPP charge payments on Abstract for one-off paid HTTP requests."
+---
+
+Charge payments are the simple MPP path: the client signs an ERC-3009 authorization and the server settles it on-chain.
+
+## 1. Install the package
+
+```bash
+npm install @abstract-foundation/mpp mppx viem zod
+```
+
+## 2. Register the server method
+
+The Abstract package exposes a server-side charge method under `@abstract-foundation/mpp/server`.
+
+```typescript
+import { Mppx } from "mppx/server";
+import { abstract } from "@abstract-foundation/mpp/server";
+import { privateKeyToAccount } from "viem/accounts";
+
+const serverAccount = privateKeyToAccount(
+  process.env.SERVER_PRIVATE_KEY as `0x${string}`
+);
+
+const mpp = Mppx.create({
+  methods: [
+    abstract.charge({
+      account: serverAccount,
+      recipient: "0xYourWalletAddress",
+      amount: "0.01",
+      testnet: true,
+    }),
+  ],
+  secretKey: process.env.MPP_SECRET_KEY!,
+});
+```
+
+## 3. Create the client method
+
+The client signs the authorization but does not broadcast a transaction directly.
+
+```typescript
+import { abstractCharge } from "@abstract-foundation/mpp/client";
+import { privateKeyToAccount } from "viem/accounts";
+
+const charge = abstractCharge({
+  account: privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`),
+});
+```
+
+## 4. What the request needs
+
+The charge request includes:
+
+- `amount`
+- `currency`
+- `decimals`
+- `recipient`
+- optional `chainId`
+
+On Abstract, the normal token path is USDC.e with 6 decimals.
+
+## 5. When to use charge mode
+
+Use charge mode when:
+
+- the client makes isolated requests
+- you want no channel lifecycle
+- the simplicity of one signature per request is acceptable
+
+## Next
+
+Move to [`Session Payments`](/ai-agents/payments/mpp/session-payments) if the same client will hit your API repeatedly.

--- a/ai-agents/payments/mpp/overview.mdx
+++ b/ai-agents/payments/mpp/overview.mdx
@@ -1,0 +1,67 @@
+---
+title: "MPP"
+description: "Use the Machine Payments Protocol on Abstract for charge payments and session-based micro-payments."
+---
+
+MPP is an HTTP-native payment protocol for paid APIs on Abstract.
+
+At a high level:
+
+- the server challenges a paid request
+- the client signs a payment credential
+- the request is retried with an authorization header
+- the server settles directly on-chain
+
+## Payment modes
+
+### Charge
+
+Use charge payments for one-off requests.
+
+- one signed authorization per request
+- built around ERC-3009 transfer authorization
+- no channel state to maintain
+
+### Session
+
+Use session payments when a client will make repeated requests.
+
+- open a channel once on-chain
+- send cumulative off-chain vouchers after that
+- settle when the server chooses
+
+## Why use MPP
+
+- one protocol for one-off and repeated machine payments
+- purpose-built for agentic HTTP flows
+- lower repeated-request overhead with session channels
+
+## MPP vs x402
+
+| | x402 | MPP |
+| --- | --- | --- |
+| **Best entry point** | Fastest existing path | Richer protocol surface |
+| **One-off payments** | Yes | Yes |
+| **Session micro-payments** | Not the core model | First-class |
+
+## Abstract package and endpoints
+
+| | |
+| --- | --- |
+| **Package** | `@abstract-foundation/mpp` |
+| **Demo** | `https://mpp.abs.xyz` |
+| **Repository** | `Abstract-Foundation/mpp-abstract` |
+| **Mainnet USDC.e** | `0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1` |
+| **Testnet USDC.e** | `0xbd28Bd5A3Ef540d1582828CE2A1a657353008C61` |
+| **Escrow contract** | `0x29635C384f451a72ED2e2a312BCeb8b0bDC0923c` |
+
+## Get started
+
+<CardGroup cols={2}>
+  <Card title="Charge Payments" icon="credit-card" href="/ai-agents/payments/mpp/charge-payments">
+    Integrate one-off paid requests.
+  </Card>
+  <Card title="Session Payments" icon="activity" href="/ai-agents/payments/mpp/session-payments">
+    Open channels and settle cumulative vouchers for repeated requests.
+  </Card>
+</CardGroup>

--- a/ai-agents/payments/mpp/session-payments.mdx
+++ b/ai-agents/payments/mpp/session-payments.mdx
@@ -1,0 +1,90 @@
+---
+title: "MPP Session Payments"
+description: "Use MPP session payments on Abstract for repeated micro-payments over HTTP."
+---
+
+Session payments use an escrow-backed channel on Abstract so the client can pay repeatedly with off-chain vouchers after one initial on-chain open.
+
+## Session lifecycle
+
+The client-side session flow has four main actions:
+
+- `open` to create the channel and sign the first voucher
+- `voucher` to increase the cumulative paid amount
+- `topUp` to add more deposit
+- `close` to finalize with a last voucher
+
+## 1. Install the package
+
+```bash
+npm install @abstract-foundation/mpp mppx viem zod
+```
+
+## 2. Create the client session method
+
+```typescript
+import { abstractSession } from "@abstract-foundation/mpp/client";
+import { privateKeyToAccount } from "viem/accounts";
+
+const session = abstractSession({
+  account: privateKeyToAccount(process.env.PRIVATE_KEY as `0x${string}`),
+  deposit: "10",
+});
+```
+
+`deposit` is the default human-readable token amount to escrow unless the server challenge provides `suggestedDeposit`.
+
+## 3. Register the server session method
+
+```typescript
+import { Mppx } from "mppx/server";
+import { abstract } from "@abstract-foundation/mpp/server";
+import { privateKeyToAccount } from "viem/accounts";
+
+const serverAccount = privateKeyToAccount(
+  process.env.SERVER_PRIVATE_KEY as `0x${string}`
+);
+
+const mpp = Mppx.create({
+  methods: [
+    abstract.session({
+      account: serverAccount,
+      recipient: "0xYourWalletAddress",
+      amount: "0.001",
+      suggestedDeposit: "1",
+      unitType: "request",
+      testnet: true,
+    }),
+  ],
+  secretKey: process.env.MPP_SECRET_KEY!,
+});
+```
+
+## 4. Request shape
+
+Session requests can include:
+
+- `amount`
+- `currency`
+- `decimals`
+- `unitType`
+- optional `recipient`
+- optional `channelId`
+- optional `escrowContract`
+- optional `suggestedDeposit`
+- optional `minVoucherDelta`
+
+## 5. Operational guidance
+
+- pick a `suggestedDeposit` that supports several expected requests
+- settle when the open channel has accumulated enough value or when you need finality
+- use `topUp` instead of reopening when the remaining deposit is too low
+- expect cumulative amounts, not independent per-request signatures
+
+## When to use session mode
+
+Use session payments when:
+
+- your agent will call the same paid API repeatedly
+- per-request on-chain overhead is too high
+- you want the HTTP flow to stay fast after the initial channel open

--- a/ai-agents/payments/x402/accepting-payments.mdx
+++ b/ai-agents/payments/x402/accepting-payments.mdx
@@ -1,0 +1,109 @@
+---
+title: "Accept x402 Payments"
+description: "Add x402 payment middleware to your server so agents and applications can pay for API access on Abstract."
+---
+
+This guide walks through adding x402 payment middleware to your server so clients must pay to access your endpoints.
+
+<Accordion title="Prerequisites">
+  - A wallet address to receive payments
+  - An existing HTTP API built with Express, Next.js, Hono, Gin, FastAPI, or Flask
+  - Node.js 18+, Go 1.21+, or Python 3.10+
+</Accordion>
+
+## 1. Install dependencies
+
+<Tabs>
+  <Tab title="Express">
+    ```bash
+    npm install @x402/express @x402/core @x402/evm
+    ```
+  </Tab>
+  <Tab title="Next.js">
+    ```bash
+    npm install @x402/next @x402/core @x402/evm
+    ```
+  </Tab>
+  <Tab title="Hono">
+    ```bash
+    npm install @x402/hono @x402/core @x402/evm
+    ```
+  </Tab>
+  <Tab title="Go">
+    ```bash
+    go get github.com/coinbase/x402/go
+    ```
+  </Tab>
+  <Tab title="Python">
+    ```bash
+    pip install x402
+    ```
+  </Tab>
+</Tabs>
+
+## 2. Add payment middleware
+
+Wrap your paid routes with x402 middleware and point it at the Abstract facilitator.
+
+```typescript
+import express from "express";
+import { paymentMiddleware, x402ResourceServer } from "@x402/express";
+import { ExactEvmScheme } from "@x402/evm/exact/server";
+import { HTTPFacilitatorClient } from "@x402/core/server";
+
+const app = express();
+const payTo = "0xYourWalletAddress";
+
+const facilitatorClient = new HTTPFacilitatorClient({
+  url: "https://facilitator.x402.abs.xyz",
+});
+
+app.use(
+  paymentMiddleware(
+    {
+      "GET /weather": {
+        accepts: [
+          {
+            scheme: "exact",
+            price: "$0.001",
+            network: "eip155:2741",
+            payTo,
+          },
+        ],
+        description: "Weather data",
+        mimeType: "application/json",
+      },
+    },
+    new x402ResourceServer(facilitatorClient).register(
+      "eip155:*",
+      new ExactEvmScheme()
+    ),
+  ),
+);
+
+app.get("/weather", (_req, res) => {
+  res.send({ weather: "sunny", temperature: 70 });
+});
+```
+
+## 3. Shape the paid resource
+
+For agent-facing APIs, define:
+
+- a stable route
+- a clear description
+- a deterministic response format
+- a price that is cheap enough for repeated automated use
+
+## 4. Test the flow
+
+The protected route should:
+
+1. return `402 Payment Required` when called without payment
+2. advertise the payment requirements in the response
+3. return `200` once the client retries with a valid payment
+
+## Next
+
+- Continue to [`Make x402 Payments`](/ai-agents/payments/x402/making-payments) to test a paying client
+- Compare with [`MPP`](/ai-agents/payments/mpp/overview) if you expect repeated micro-payments

--- a/ai-agents/payments/x402/making-payments.mdx
+++ b/ai-agents/payments/x402/making-payments.mdx
@@ -1,0 +1,85 @@
+---
+title: "Make x402 Payments"
+description: "Use the x402 client SDK to access payment-protected resources on Abstract."
+---
+
+This guide walks through building a client that can automatically pay for x402-protected resources on Abstract.
+
+<Accordion title="Prerequisites">
+  - A wallet with USDC on Abstract mainnet or testnet
+  - Node.js 18+, Go 1.21+, or Python 3.10+
+</Accordion>
+
+## 1. Install the client SDK
+
+<Tabs>
+  <Tab title="Fetch">
+    ```bash
+    npm install @x402/fetch @x402/core @x402/evm viem
+    ```
+  </Tab>
+  <Tab title="Axios">
+    ```bash
+    npm install @x402/axios @x402/core @x402/evm viem axios
+    ```
+  </Tab>
+  <Tab title="Go">
+    ```bash
+    go get github.com/coinbase/x402/go
+    ```
+  </Tab>
+  <Tab title="Python">
+    ```bash
+    pip install "x402[httpx]"
+    ```
+  </Tab>
+</Tabs>
+
+## 2. Create a signer
+
+```typescript
+import { privateKeyToAccount } from "viem/accounts";
+
+const signer = privateKeyToAccount(
+  process.env.PRIVATE_KEY as `0x${string}`
+);
+```
+
+## 3. Wrap your HTTP client
+
+```typescript
+import { wrapFetchWithPayment } from "@x402/fetch";
+import { x402Client } from "@x402/core/client";
+import { ExactEvmScheme } from "@x402/evm/exact/client";
+import { privateKeyToAccount } from "viem/accounts";
+
+const signer = privateKeyToAccount(
+  process.env.PRIVATE_KEY as `0x${string}`
+);
+
+const client = new x402Client();
+client.register("eip155:*", new ExactEvmScheme(signer));
+
+const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+
+const response = await fetchWithPayment(
+  "https://api.example.com/weather",
+  { method: "GET" },
+);
+
+const data = await response.json();
+console.log(data);
+```
+
+## 4. Agent runtime notes
+
+For an automated agent:
+
+- keep the signer scoped to the smallest viable balance
+- separate read-only and paid-request workflows
+- log payment receipts so you can reconcile usage later
+
+## Next
+
+- Continue to [`AGW CLI`](/ai-agents/wallet-access/agw-cli-overview) if the agent should use AGW instead of a raw private key
+- Compare with [`MPP`](/ai-agents/payments/mpp/overview) if your client will make repeated paid requests

--- a/ai-agents/payments/x402/overview.mdx
+++ b/ai-agents/payments/x402/overview.mdx
@@ -1,0 +1,63 @@
+---
+title: "x402"
+description: "Accept and make HTTP payments on Abstract using the x402 protocol."
+---
+
+[x402](https://x402.org) is an open payment standard that activates [HTTP 402 Payment Required](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/402) for practical use.
+
+It lets agents and applications charge for API access with a standard HTTP flow:
+
+1. Client requests a paid resource
+2. Server responds with `402 Payment Required`
+3. Client signs a payment payload
+4. Client retries with payment attached
+5. A facilitator verifies and settles on-chain
+
+## When to use x402
+
+Use x402 when you want:
+
+- the simplest pay-per-request integration path
+- a public facilitator on Abstract
+- a clean split between client and server middleware
+
+Use [`MPP`](/ai-agents/payments/mpp/overview) instead when you want HTTP-native charge and session payment modes in one protocol, especially for repeated micro-payments.
+
+## Abstract facilitator
+
+Abstract runs a public x402 facilitator that any developer can use:
+
+| | |
+| --- | --- |
+| **Facilitator URL** | `https://facilitator.x402.abs.xyz` |
+| **Service fees** | None |
+| **Gas fees** | Sponsored via paymaster |
+| **Supported networks** | Abstract mainnet (`eip155:2741`), Abstract testnet (`eip155:11124`) |
+
+## Supported token
+
+The facilitator works with any [ERC-3009](https://eips.ethereum.org/EIPS/eip-3009)-capable token on Abstract. USDC is the recommended token:
+
+| Network | Token | Address |
+| --- | --- | --- |
+| Mainnet (`eip155:2741`) | USDC | `0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1` |
+| Testnet (`eip155:11124`) | USDC | `0xe4C7fBB0a626ed208021ccabA6Be1566905E2dFc` |
+
+## x402 vs MPP
+
+| | x402 | MPP |
+| --- | --- | --- |
+| **Best for** | Fastest path to paid APIs | Charge plus session-based agent payments |
+| **Primary model** | 402 challenge + facilitator settlement | HTTP-native method negotiation |
+| **Repeated micro-payments** | Possible, but not the focus | First-class via session channels |
+
+## Get started
+
+<CardGroup cols={2}>
+  <Card title="Accept x402 Payments" icon="server" href="/ai-agents/payments/x402/accepting-payments">
+    Add payment middleware to your API.
+  </Card>
+  <Card title="Make x402 Payments" icon="credit-card" href="/ai-agents/payments/x402/making-payments">
+    Build a client that can pay x402-protected resources.
+  </Card>
+</CardGroup>

--- a/ai-agents/resources/contracts-and-endpoints.mdx
+++ b/ai-agents/resources/contracts-and-endpoints.mdx
@@ -1,0 +1,37 @@
+---
+title: "Contracts and Endpoints"
+description: "Reference endpoints, token addresses, chain IDs, and package names for Abstract agent workflows."
+---
+
+## x402
+
+| | |
+| --- | --- |
+| **Facilitator** | `https://facilitator.x402.abs.xyz` |
+| **Mainnet chain ID** | `eip155:2741` |
+| **Testnet chain ID** | `eip155:11124` |
+| **Mainnet USDC** | `0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1` |
+| **Testnet USDC** | `0xe4C7fBB0a626ed208021ccabA6Be1566905E2dFc` |
+
+## MPP
+
+| | |
+| --- | --- |
+| **Package** | `@abstract-foundation/mpp` |
+| **Repository** | `Abstract-Foundation/mpp-abstract` |
+| **Demo** | `https://mpp.abs.xyz` |
+| **Mainnet USDC.e** | `0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1` |
+| **Testnet USDC.e** | `0xbd28Bd5A3Ef540d1582828CE2A1a657353008C61` |
+| **Escrow contract** | `0x29635C384f451a72ED2e2a312BCeb8b0bDC0923c` |
+
+## AGW CLI and docs tooling
+
+| | |
+| --- | --- |
+| **AGW CLI package** | `@abstract-foundation/agw-cli` |
+| **AGW CLI site** | `https://cli.abs.xyz/` |
+| **AGW CLI repo** | `https://github.com/Abstract-Foundation/agw-cli` |
+| **Docs MCP** | `https://docs.abs.xyz/mcp` |
+| **llms.txt** | `https://docs.abs.xyz/llms.txt` |
+| **llms-full.txt** | `https://docs.abs.xyz/llms-full.txt` |
+| **SKILL.MD** | `https://docs.abs.xyz/skill.md` |

--- a/ai-agents/resources/llms-full-txt.mdx
+++ b/ai-agents/resources/llms-full-txt.mdx
@@ -1,0 +1,26 @@
+---
+title: "llms-full.txt"
+description: "The complete Abstract documentation in a single file for AI tools."
+---
+
+`llms-full.txt` contains the full text of every page in Abstract's documentation in one file.
+
+<Card title="View llms-full.txt" icon="arrow-up-right-from-square" href="https://docs.abs.xyz/llms-full.txt">
+  `https://docs.abs.xyz/llms-full.txt`
+</Card>
+
+## When to use it
+
+Use `llms-full.txt` when you want an AI tool to have complete knowledge of Abstract's documentation.
+
+- Upload it as a knowledge file to a Claude Project
+- Use it for a full-context custom GPT
+- Feed it into local RAG pipelines that need full page text
+
+## Compared to llms.txt
+
+| | [`llms.txt`](/ai-agents/resources/llms-txt) | `llms-full.txt` |
+| --- | --- | --- |
+| **Content** | Page titles, URLs, descriptions | Full page content |
+| **Size** | Small | Large |
+| **Best for** | Discovery | Comprehensive context |

--- a/ai-agents/resources/llms-txt.mdx
+++ b/ai-agents/resources/llms-txt.mdx
@@ -1,0 +1,18 @@
+---
+title: "llms.txt"
+description: "A lightweight index of Abstract documentation for use with AI tools."
+---
+
+[`llms.txt`](https://llmstxt.org/) is a lightweight index of every page in Abstract's documentation: page titles, URLs, and descriptions.
+
+<Card title="View llms.txt" icon="arrow-up-right-from-square" href="https://docs.abs.xyz/llms.txt">
+  `https://docs.abs.xyz/llms.txt`
+</Card>
+
+## When to use it
+
+Use `llms.txt` when you want an AI tool to know what documentation exists without feeding it the full content.
+
+- Add Abstract docs to a Cursor project via `@docs`
+- Provide routing context to a custom GPT
+- Power lightweight retrieval that only needs page discovery

--- a/ai-agents/resources/overview.mdx
+++ b/ai-agents/resources/overview.mdx
@@ -1,0 +1,37 @@
+---
+title: "Agent Resources"
+description: "Use docs MCP, llms.txt, llms-full.txt, and SKILL.MD to give coding agents the right Abstract context."
+---
+
+These resources help coding agents and AI tools understand Abstract documentation without manually pasting large amounts of context.
+
+<CardGroup cols={2}>
+  <Card title="Docs MCP" icon="plug" href="https://docs.abs.xyz/mcp">
+    Connect an MCP-capable tool directly to Abstract docs.
+  </Card>
+  <Card title="llms.txt" icon="list" href="/ai-agents/resources/llms-txt">
+    Use a lightweight index of the docs.
+  </Card>
+  <Card title="llms-full.txt" icon="book-open" href="/ai-agents/resources/llms-full-txt">
+    Use the full text of the docs in one file.
+  </Card>
+  <Card title="SKILL.MD" icon="robot" href="/ai-agents/resources/skill-md">
+    Use a cheat sheet optimized for coding-agent execution.
+  </Card>
+</CardGroup>
+
+## Markdown pages
+
+Append `.md` to any docs URL to get a clean Markdown version:
+
+- `https://docs.abs.xyz/overview.md`
+- `https://docs.abs.xyz/abstract-global-wallet/overview.md`
+
+## When to use which
+
+| Resource | Best for |
+| --- | --- |
+| **Docs MCP** | Tool-based retrieval from an MCP-capable host |
+| **llms.txt** | Discovery and routing |
+| **llms-full.txt** | Full-context ingestion |
+| **SKILL.MD** | Task completion, workflows, and decision support |

--- a/ai-agents/resources/skill-md.mdx
+++ b/ai-agents/resources/skill-md.mdx
@@ -1,0 +1,33 @@
+---
+title: "SKILL.MD"
+description: "A structured cheat sheet that helps AI coding agents build on Abstract correctly."
+---
+
+[`skill.md`](https://www.mintlify.com/blog/skill-md) is a structured cheat sheet for AI coding agents. Instead of raw documentation, it provides decision tables, workflows, gotchas, and quick-reference data.
+
+<Card title="View SKILL.MD" icon="arrow-up-right-from-square" href="https://docs.abs.xyz/skill.md">
+  `https://docs.abs.xyz/skill.md`
+</Card>
+
+## What's in it
+
+- Quick reference for network config, chain IDs, packages, and compiler settings
+- Decision tables for common tooling and wallet choices
+- Step-by-step workflows for deployment and integration
+- Gotchas that prevent common Abstract-specific mistakes
+
+## When to use it
+
+- Install it as a skill: `npx skills add https://docs.abs.xyz`
+- Add it to a Claude Project as a knowledge file
+- Give it to coding agents that need execution guidance instead of just reference text
+
+`skill.md` is also available at `https://docs.abs.xyz/.well-known/skills/default/skill.md`
+
+## Compared to llms.txt
+
+| | [`llms.txt`](/ai-agents/resources/llms-txt) | `skill.md` |
+| --- | --- | --- |
+| **Purpose** | Documentation index | Agent cheat sheet |
+| **Style** | Structured links | Workflows and decision support |
+| **Best for** | Finding pages | Completing tasks correctly |

--- a/ai-agents/wallet-access/agw-cli-overview.mdx
+++ b/ai-agents/wallet-access/agw-cli-overview.mdx
@@ -1,0 +1,57 @@
+---
+title: "AGW CLI"
+description: "Use AGW CLI as an agent-first interface to Abstract Global Wallet."
+---
+
+AGW CLI is an agent-first CLI for Abstract Global Wallet.
+
+It gives an agent structured JSON input and output for wallet operations without exposing the wallet's private key to the agent runtime.
+
+## What it can do
+
+- read wallet address, balances, and token inventory
+- preview and execute transactions
+- sign messages and transactions
+- write to contracts and deploy contracts
+- discover apps on Abstract
+- query Abstract Portal data
+- serve the same capabilities over MCP
+
+## Why use it
+
+Use AGW CLI when you want:
+
+- a CLI-first or MCP-first wallet integration
+- preview-first writes with explicit execution
+- session-key-style delegation through a companion approval flow
+- schema introspection for agent tooling
+
+## Command groups
+
+| Group | Examples |
+| --- | --- |
+| `wallet` | `address`, `balances`, `tokens list` |
+| `tx` | `preview`, `send`, `calls`, `transfer-token` |
+| `contract` | `write`, `deploy` |
+| `auth` | `init`, `revoke` |
+| `session` | `status`, `doctor` |
+| `app` | `list`, `show` |
+| `portal` | `streams list`, `user-profile get` |
+| `mcp` | `serve` |
+
+## Relationship to AGW SDK docs
+
+This section covers the agent workflow. For direct app integration with AGW SDKs, use the [`Abstract Global Wallet`](/abstract-global-wallet/overview) docs.
+
+For the underlying session-key model, see [`Session keys`](/abstract-global-wallet/session-keys/overview).
+
+## Get started
+
+<CardGroup cols={2}>
+  <Card title="Install and Authenticate" icon="key" href="/ai-agents/wallet-access/install-and-authenticate">
+    Install AGW CLI and link it to a wallet.
+  </Card>
+  <Card title="Run AGW as MCP" icon="plug" href="/ai-agents/wallet-access/run-as-mcp">
+    Expose AGW capabilities to MCP-capable hosts.
+  </Card>
+</CardGroup>

--- a/ai-agents/wallet-access/install-and-authenticate.mdx
+++ b/ai-agents/wallet-access/install-and-authenticate.mdx
@@ -1,0 +1,46 @@
+---
+title: "Install and Authenticate"
+description: "Install AGW CLI, link it to an Abstract Global Wallet, and verify the session."
+---
+
+## 1. Install the CLI
+
+AGW CLI requires Node.js 18+ and npm 10+.
+
+```bash
+npm install -g @abstract-foundation/agw-cli
+agw-cli --version
+```
+
+## 2. Start authentication
+
+Run the init flow:
+
+```bash
+agw-cli auth init --json '{"chainId":2741}' --execute
+```
+
+This opens the companion app in your browser, where you connect an existing AGW or create a new one and approve the agent signer for this machine.
+
+## 3. Verify the session
+
+```bash
+agw-cli session doctor --json '{}'
+agw-cli session status --json '{"fields":["status","readiness","accountAddress","policyPreset"]}'
+```
+
+## 4. Install the AGW skills
+
+```bash
+npx skills add https://github.com/Abstract-Foundation/agw-cli/tree/main/packages/agw-cli/skills -y
+```
+
+## What you get
+
+- a local device authorization key
+- a linked AGW session for this machine
+- policy-scoped permissions enforced through the companion flow
+
+## Next
+
+Continue to [`Run AGW as MCP`](/ai-agents/wallet-access/run-as-mcp) if your host supports MCP.

--- a/ai-agents/wallet-access/run-as-mcp.mdx
+++ b/ai-agents/wallet-access/run-as-mcp.mdx
@@ -1,0 +1,51 @@
+---
+title: "Run AGW as MCP"
+description: "Expose AGW CLI capabilities through the built-in MCP server."
+---
+
+AGW CLI ships with a built-in MCP server generated from the same command registry as the CLI.
+
+## Start the MCP server
+
+```bash
+agw-cli mcp serve --sanitize strict
+```
+
+## Generate config
+
+```bash
+agw-cli mcp-config
+agw-cli mcp-config --npx
+```
+
+Use the plain `mcp-config` output when `agw-cli` is already installed on the machine. Use `--npx` when you want an npx-based host configuration.
+
+## Good host fits
+
+- Claude Code
+- Codex-compatible MCP hosts
+- Gemini
+- other MCP-capable local agent hosts
+
+## What the MCP server exposes
+
+The MCP server inherits the CLI command surface, including:
+
+- wallet reads
+- transaction preview and execution
+- contract actions
+- app discovery
+- Portal queries
+
+## Recommended setup
+
+1. Complete [`Install and Authenticate`](/ai-agents/wallet-access/install-and-authenticate)
+2. Start `agw-cli mcp serve --sanitize strict`
+3. Paste the config snippet into your MCP host
+4. Test a read-only command before enabling write workflows
+
+## Write-safety model
+
+- reads can run directly
+- state-changing operations should be previewed first
+- execution requires explicit `--execute`

--- a/ai-agents/wallet-access/security-and-session-model.mdx
+++ b/ai-agents/wallet-access/security-and-session-model.mdx
@@ -1,0 +1,36 @@
+---
+title: "Security and Session Model"
+description: "Understand how AGW CLI delegates wallet actions to an agent without exposing the wallet's private key."
+---
+
+AGW CLI uses a delegated signer model.
+
+The wallet's signing key stays managed by the AGW stack, while the CLI creates a local device authorization key for this machine and binds it through the companion approval flow.
+
+## High-level flow
+
+1. AGW CLI generates a local device key
+2. The companion app opens in the browser
+3. The user approves the signer and policy scope
+4. The session is saved locally
+5. Future requests are checked against the approved policy
+
+## Why this matters
+
+- the agent does not need the wallet's private key
+- permissions can be scoped by policy
+- state-changing actions stay preview-first
+
+## Local material
+
+The CLI stores local session material under the AGW home directory and uses restrictive file permissions for sensitive values.
+
+## Policy presets
+
+During onboarding, the signer is bound to a policy preset that constrains what the agent can do. Both the local CLI flow and the backing policy enforcement have to agree before a write action executes.
+
+## Related AGW docs
+
+- [`Abstract Global Wallet`](/abstract-global-wallet/overview)
+- [`Session keys`](/abstract-global-wallet/session-keys/overview)
+- [`Going to Production`](/abstract-global-wallet/session-keys/going-to-production)

--- a/ai-agents/wallet-access/wallet-reads-and-transactions.mdx
+++ b/ai-agents/wallet-access/wallet-reads-and-transactions.mdx
@@ -1,0 +1,49 @@
+---
+title: "Wallet Reads and Transactions"
+description: "Common AGW CLI workflows for balances, transactions, app discovery, and Portal data."
+---
+
+This page focuses on practical agent workflows rather than full command reference.
+
+## Read wallet identity and balances
+
+```bash
+agw-cli wallet address --json '{}'
+agw-cli wallet balances --json '{"fields":["native","tokens"]}'
+agw-cli wallet tokens list --json '{"pageSize":25,"fields":["items.symbol","items.value","nextCursor"]}'
+```
+
+## Preview before execution
+
+```bash
+agw-cli tx send --json '{"to":"0x...","data":"0x1234","value":"0"}' --dry-run
+```
+
+After review:
+
+```bash
+agw-cli tx send --json '{"to":"0x...","data":"0x1234","value":"0"}' --execute
+```
+
+## Sign messages and transactions
+
+```bash
+agw-cli tx sign-message --json '{"message":"hello"}'
+agw-cli tx sign-transaction --json '{"to":"0x...","value":"0"}'
+```
+
+## Discover apps and Portal data
+
+```bash
+agw-cli app list --json '{"pageSize":10,"fields":["items.id","items.name"]}'
+agw-cli portal user-profile get --json '{"address":"0x..."}'
+```
+
+## Use schema introspection
+
+```bash
+agw-cli schema list
+agw-cli schema get --json '{"command":"wallet balances"}'
+```
+
+This is useful when the caller is itself an agent and needs machine-readable input and output shapes.

--- a/docs.json
+++ b/docs.json
@@ -146,49 +146,6 @@
         ]
       },
       {
-        "tab": "AI Agents",
-        "groups": [
-          {
-            "group": "Overview",
-            "pages": [
-              "ai-agents/overview",
-              "ai-agents/build-paths"
-            ]
-          },
-          {
-            "group": "Payments",
-            "pages": [
-              "ai-agents/payments/x402/overview",
-              "ai-agents/payments/x402/accepting-payments",
-              "ai-agents/payments/x402/making-payments",
-              "ai-agents/payments/mpp/overview",
-              "ai-agents/payments/mpp/charge-payments",
-              "ai-agents/payments/mpp/session-payments"
-            ]
-          },
-          {
-            "group": "Wallet Access",
-            "pages": [
-              "ai-agents/wallet-access/agw-cli-overview",
-              "ai-agents/wallet-access/install-and-authenticate",
-              "ai-agents/wallet-access/run-as-mcp",
-              "ai-agents/wallet-access/wallet-reads-and-transactions",
-              "ai-agents/wallet-access/security-and-session-model"
-            ]
-          },
-          {
-            "group": "Resources",
-            "pages": [
-              "ai-agents/resources/overview",
-              "ai-agents/resources/llms-txt",
-              "ai-agents/resources/llms-full-txt",
-              "ai-agents/resources/skill-md",
-              "ai-agents/resources/contracts-and-endpoints"
-            ]
-          }
-        ]
-      },
-      {
         "tab": "Abstract Global Wallet",
         "groups": [
           {
@@ -260,6 +217,49 @@
             "pages": [
               "abstract-global-wallet/agw-client/getSmartAccountAddressFromInitialSigner",
               "abstract-global-wallet/agw-client/transformEIP1193Provider"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "AI Agents",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "ai-agents/overview",
+              "ai-agents/build-paths"
+            ]
+          },
+          {
+            "group": "Payments",
+            "pages": [
+              "ai-agents/payments/x402/overview",
+              "ai-agents/payments/x402/accepting-payments",
+              "ai-agents/payments/x402/making-payments",
+              "ai-agents/payments/mpp/overview",
+              "ai-agents/payments/mpp/charge-payments",
+              "ai-agents/payments/mpp/session-payments"
+            ]
+          },
+          {
+            "group": "Wallet Access",
+            "pages": [
+              "ai-agents/wallet-access/agw-cli-overview",
+              "ai-agents/wallet-access/install-and-authenticate",
+              "ai-agents/wallet-access/run-as-mcp",
+              "ai-agents/wallet-access/wallet-reads-and-transactions",
+              "ai-agents/wallet-access/security-and-session-model"
+            ]
+          },
+          {
+            "group": "Resources",
+            "pages": [
+              "ai-agents/resources/overview",
+              "ai-agents/resources/llms-txt",
+              "ai-agents/resources/llms-full-txt",
+              "ai-agents/resources/skill-md",
+              "ai-agents/resources/contracts-and-endpoints"
             ]
           }
         ]

--- a/docs.json
+++ b/docs.json
@@ -26,44 +26,6 @@
             ]
           },
           {
-            "group": "AI Agents",
-            "pages": [
-              "ai-agents/overview",
-              "ai-agents/build-paths",
-              {
-                "group": "Payments",
-                "pages": [
-                  "ai-agents/payments/x402/overview",
-                  "ai-agents/payments/x402/accepting-payments",
-                  "ai-agents/payments/x402/making-payments",
-                  "ai-agents/payments/mpp/overview",
-                  "ai-agents/payments/mpp/charge-payments",
-                  "ai-agents/payments/mpp/session-payments"
-                ]
-              },
-              {
-                "group": "Wallet Access",
-                "pages": [
-                  "ai-agents/wallet-access/agw-cli-overview",
-                  "ai-agents/wallet-access/install-and-authenticate",
-                  "ai-agents/wallet-access/run-as-mcp",
-                  "ai-agents/wallet-access/wallet-reads-and-transactions",
-                  "ai-agents/wallet-access/security-and-session-model"
-                ]
-              },
-              {
-                "group": "Resources",
-                "pages": [
-                  "ai-agents/resources/overview",
-                  "ai-agents/resources/llms-txt",
-                  "ai-agents/resources/llms-full-txt",
-                  "ai-agents/resources/skill-md",
-                  "ai-agents/resources/contracts-and-endpoints"
-                ]
-              }
-            ]
-          },
-          {
             "group": "Build on Abstract",
             "pages": [
               "build-on-abstract/getting-started",
@@ -179,6 +141,49 @@
                   "infrastructure/nodes/running-a-node"
                 ]
               }
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "AI Agents",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "ai-agents/overview",
+              "ai-agents/build-paths"
+            ]
+          },
+          {
+            "group": "Payments",
+            "pages": [
+              "ai-agents/payments/x402/overview",
+              "ai-agents/payments/x402/accepting-payments",
+              "ai-agents/payments/x402/making-payments",
+              "ai-agents/payments/mpp/overview",
+              "ai-agents/payments/mpp/charge-payments",
+              "ai-agents/payments/mpp/session-payments"
+            ]
+          },
+          {
+            "group": "Wallet Access",
+            "pages": [
+              "ai-agents/wallet-access/agw-cli-overview",
+              "ai-agents/wallet-access/install-and-authenticate",
+              "ai-agents/wallet-access/run-as-mcp",
+              "ai-agents/wallet-access/wallet-reads-and-transactions",
+              "ai-agents/wallet-access/security-and-session-model"
+            ]
+          },
+          {
+            "group": "Resources",
+            "pages": [
+              "ai-agents/resources/overview",
+              "ai-agents/resources/llms-txt",
+              "ai-agents/resources/llms-full-txt",
+              "ai-agents/resources/skill-md",
+              "ai-agents/resources/contracts-and-endpoints"
             ]
           }
         ]

--- a/docs.json
+++ b/docs.json
@@ -26,20 +26,41 @@
             ]
           },
           {
-            "group": "AI & LLMs",
+            "group": "AI Agents",
             "pages": [
-              "ai-and-llms/overview",
-              "ai-and-llms/llms-txt",
-              "ai-and-llms/llms-full-txt",
-              "ai-and-llms/skill-md"
-            ]
-          },
-          {
-            "group": "Payments (x402)",
-            "pages": [
-              "x402/overview",
-              "x402/accepting-payments",
-              "x402/making-payments"
+              "ai-agents/overview",
+              "ai-agents/build-paths",
+              {
+                "group": "Payments",
+                "pages": [
+                  "ai-agents/payments/x402/overview",
+                  "ai-agents/payments/x402/accepting-payments",
+                  "ai-agents/payments/x402/making-payments",
+                  "ai-agents/payments/mpp/overview",
+                  "ai-agents/payments/mpp/charge-payments",
+                  "ai-agents/payments/mpp/session-payments"
+                ]
+              },
+              {
+                "group": "Wallet Access",
+                "pages": [
+                  "ai-agents/wallet-access/agw-cli-overview",
+                  "ai-agents/wallet-access/install-and-authenticate",
+                  "ai-agents/wallet-access/run-as-mcp",
+                  "ai-agents/wallet-access/wallet-reads-and-transactions",
+                  "ai-agents/wallet-access/security-and-session-model"
+                ]
+              },
+              {
+                "group": "Resources",
+                "pages": [
+                  "ai-agents/resources/overview",
+                  "ai-agents/resources/llms-txt",
+                  "ai-agents/resources/llms-full-txt",
+                  "ai-agents/resources/skill-md",
+                  "ai-agents/resources/contracts-and-endpoints"
+                ]
+              }
             ]
           },
           {


### PR DESCRIPTION
## Summary
- Replace the separate AI & LLMs and Payments (x402) nav groups with a unified AI Agents section.
- Add new docs for build paths, x402, MPP, AGW CLI/MCP, and agent resources under the main Documentation tab.
- Cross-link the AGW landing page back to the new AI Agents wallet-access docs.