### PR TITLE
Split Payments sidebar into x402 and MPP sub-groups

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -234,12 +234,22 @@
           {
             "group": "Payments",
             "pages": [
-              "ai-agents/payments/x402/overview",
-              "ai-agents/payments/x402/accepting-payments",
-              "ai-agents/payments/x402/making-payments",
-              "ai-agents/payments/mpp/overview",
-              "ai-agents/payments/mpp/charge-payments",
-              "ai-agents/payments/mpp/session-payments"
+              {
+                "group": "x402",
+                "pages": [
+                  "ai-agents/payments/x402/overview",
+                  "ai-agents/payments/x402/accepting-payments",
+                  "ai-agents/payments/x402/making-payments"
+                ]
+              },
+              {
+                "group": "MPP",
+                "pages": [
+                  "ai-agents/payments/mpp/overview",
+                  "ai-agents/payments/mpp/charge-payments",
+                  "ai-agents/payments/mpp/session-payments"
+                ]
+              }
             ]
           },
           {


### PR DESCRIPTION
Splits the flat Payments group in the AI Agents tab into two nested sub-groups — x402 and MPP — so each payment protocol has its own collapsible section in the sidebar.