### PR TITLE
docs: remove duplicate word 'section' in list-of-system-contracts.mdx

### DIFF
--- a/how-abstract-works/system-contracts/list-of-system-contracts.mdx
+++ b/how-abstract-works/system-contracts/list-of-system-contracts.mdx
@@ -233,7 +233,7 @@ This contract is used for sending messages from Abstract to Ethereum.
 It is used by the [KnownCodesStorage](#knowncodesstorage) contract to publish the
 code hash of smart contracts to Ethereum.
 
-Learn more about what data is sent in the [contract deployment section](/how-abstract-works/evm-differences/contract-deployment) section.
+Learn more about what data is sent in the [contract deployment section](/how-abstract-works/evm-differences/contract-deployment).
 
 **Contract Address:** `0x0000000000000000000000000000000000008008`
 


### PR DESCRIPTION
## What
Word duplication on line 236 of list-of-system-contracts.mdx: "section" appears twice.

## How
Removed the duplicate "section" word.