### PR TITLE
Update getSessionHash repo link in revokeSessions docs

### DIFF
--- a/abstract-global-wallet/agw-client/session-keys/revokeSessions.mdx
+++ b/abstract-global-wallet/agw-client/session-keys/revokeSessions.mdx
@@ -12,7 +12,7 @@ This allows you to invalidate existing session keys, preventing them from being 
 Revoke session(s) by providing either:
 
 - The session configuration object(s) (see [parameters](#parameters)).
-- The session hash(es) returned by [getSessionHash()](https://github.com/Abstract-Foundation/agw-sdk/blob/ea8db618788c6e93100efae7f475da6f4f281aeb/packages/agw-client/src/sessions.ts#L213).
+- The session hash(es) returned by [getSessionHash()](https://github.com/Abstract-Foundation/abstract-packages/blob/ca46a71e1f6bda5d86c6ee98c209057d68852510/packages/agw-client/src/sessions.ts#L213).
 
 ```tsx
 import { useAbstractClient } from "@abstract-foundation/agw-react";


### PR DESCRIPTION
## Summary
- update the `getSessionHash()` GitHub link in `abstract-global-wallet/agw-client/session-keys/revokeSessions.mdx`
- point the URL at `Abstract-Foundation/abstract-packages`
- pin the link to commit `ca46a71e1f6bda5d86c6ee98c209057d68852510`

## Testing
- not run (documentation-only change)
- verified the updated link target in `revokeSessions.mdx`