### PR TITLE
docs: add OpenChainBench to RPC providers

### DIFF
--- a/ecosystem/rpc-providers.mdx
+++ b/ecosystem/rpc-providers.mdx
@@ -16,4 +16,5 @@ description: "Discover the RPC providers available on Abstract."
     href="https://www.quicknode.com/docs/abstract"
   />
   <Card title="dRPC" icon="link" href="https://drpc.org/chainlist/abstract" />
+  <Card title="OpenChainBench" icon="chart-bar" href="https://openchainbench.com/benchmarks/abstract-rpc" />
 </CardGroup>


### PR DESCRIPTION
Adds [OpenChainBench](https://openchainbench.com/benchmarks/abstract-rpc) to the RPC providers page.

OpenChainBench continuously probes every free, no-key public Abstract RPC endpoint (including the ones already listed here) and publishes live latency rankings (p50/p90/p99) from 3 regions: US-East, EU-West, and Singapore. Probes run every 60 seconds; results update in real-time.

The page complements the existing provider links — it gives developers a data-driven way to pick between the listed providers based on their region and use case, rather than having to benchmark manually.

Currently tracking: Abstract Foundation official endpoint, dRPC, Thirdweb.