### PR TITLE
docs: add Uniblock to RPC providers

### DIFF
--- a/ecosystem/rpc-providers.mdx
+++ b/ecosystem/rpc-providers.mdx
@@ -16,4 +16,5 @@ description: "Discover the RPC providers available on Abstract."
     href="https://www.quicknode.com/docs/abstract"
   />
   <Card title="dRPC" icon="link" href="https://drpc.org/chainlist/abstract" />
+  <Card title="Uniblock" icon="link" href="https://uniblock.dev/chains/abstract/?utm_source=abstract-docs&utm_medium=ecosystem-docs&utm_campaign=ecosystem&utm_content=intro" />
 </CardGroup>


### PR DESCRIPTION
Adds Uniblock to the RPC providers card grid.

Uniblock routes JSON-RPC requests for Abstract across 55+ upstream providers
with automatic failover, so apps keep serving if any single provider degrades.

**Scope:** one line in `ecosystem/rpc-providers.mdx`. No other files touched.

- Matches the existing one-line `<Card>` format used by the Alchemy and dRPC entries
- Uses `icon="link"`, consistent with all four existing cards
- Appended last, preserving the section's existing non-alphabetical order

Disclosure: I work at Uniblock. Happy to adjust the wording, the link, or the
placement to fit your guidelines.