### PR TITLE
Fix missing imports in factory dependencies deployment example

### DIFF
--- a/build-on-abstract/smart-contracts/hardhat/deploying-contracts.mdx
+++ b/build-on-abstract/smart-contracts/hardhat/deploying-contracts.mdx
@@ -195,22 +195,25 @@ to be provided within the factory dependencies array.
 
 [Learn more about factory dependencies](/how-abstract-works/evm-differences/contract-deployment).
 
-```typescript [expandable] {5-6,16}
+```typescript [expandable] {4,9}
 import { Wallet } from "zksync-ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { Deployer } from "@matterlabs/hardhat-zksync";
+import { vars } from "hardhat/config";
 
 // Additional bytecode dependencies (typically imported from artifacts)
 const contractBytecode = "0x..."; // Your contract bytecode
 
-const wallet = new Wallet(vars.get("DEPLOYER_PRIVATE_KEY"));
-const deployer = new Deployer(hre, wallet);
-const artifact = await deployer.loadArtifact("FactoryContract");
-const contract = await deployer.deploy(
-  artifact,
-  ["Hello world!"],
-  "create",
-  {},
-  [contractBytecode]
-);
+export default async function (hre: HardhatRuntimeEnvironment) {
+  const wallet = new Wallet(vars.get("DEPLOYER_PRIVATE_KEY"));
+  const deployer = new Deployer(hre, wallet);
+  const artifact = await deployer.loadArtifact("FactoryContract");
+  const contract = await deployer.deploy(
+    artifact,
+    ["Hello world!"],
+    "create",
+    {},
+    [contractBytecode]
+  );
+}
 ```


### PR DESCRIPTION
## Summary

Fix the `Additional Factory Dependencies` deployment example in `build-on-abstract/smart-contracts/hardhat/deploying-contracts.mdx`.

The example referenced `vars` and `hre` without importing or defining them, causing TypeScript compilation errors when the snippet was checked independently.

## Changes

- Added the missing `vars` import from `hardhat/config`.
- Wrapped the deployment logic in a Hardhat deployment function that receives `hre` as a `HardhatRuntimeEnvironment`.
- Updated the code highlighting to reflect the added lines.

## Verification

Reproduced the issue locally with TypeScript. The original example produced:

- `TS2304: Cannot find name 'vars'`
- `TS2304: Cannot find name 'hre'`

Screen:
<img width="960" height="174" alt="image" src="https://github.com/user-attachments/assets/74a92aaa-deba-4336-8b3a-8338a26f4740" />

After adding the missing import and `hre` parameter, these two errors were no longer reported.