### PR TITLE
fix(api-reference): correct duplicate l2LegacySharedBridge key in BridgeContractsResponse

### DIFF
--- a/api-reference/openapi.json
+++ b/api-reference/openapi.json
@@ -6180,17 +6180,17 @@
             "l2Erc20DefaultBridge": {
               "type": "string",
               "description": "L2 ERC20 default bridge address",
-              "example": "0x0000000000000000000000000000000000000000"
+              "example": "0x0000000000000000000000000000000000010003"
             },
             "l2LegacySharedBridge": {
               "type": "string",
               "description": "L2 legacy shared bridge address",
               "example": "0x954ba8223a6bfec1cc3867139243a02ba0bc66e4"
             },
-            "l2LegacySharedBridge": {
+            "l2SharedDefaultBridge": {
               "type": "string",
-              "description": "L2 Shared default bridge address",
-              "example": "0x0000000000000000000000000000000000000000"
+              "description": "L2 shared default bridge address",
+              "example": "0x0000000000000000000000000000000000010003"
             },
             "l2WethBridge": {
               "type": "string",


### PR DESCRIPTION
The `BridgeContractsResponse` schema in `api-reference/openapi.json` defines `l2LegacySharedBridge` twice, which makes the file invalid.

### Impact

Running `mint dev` on a clean clone fails to load the OpenAPI tab entirely:

    erro Openapi file api-reference/openapi.json defined in tab in your docs.json exists but
         is invalid: Invalid JSON or YAML syntax: duplicated mapping key (6190:13)

### Root cause

The second entry was meant to be `l2SharedDefaultBridge`. Its own description already said "L2 Shared default bridge address", so this looks like a copy/paste slip when the field was added.

### Verification

Checked against the live mainnet RPC (`zks_getBridgeContracts` on `https://api.mainnet.abs.xyz`):

```json
{
  "l1Erc20DefaultBridge": "0x57891966931eb4bb6fb81430e6ce0a03aabde063",
  "l1SharedDefaultBridge": "0x8829ad80e425c646dab305381ff105169feece56",
  "l1WethBridge": "0x0000000000000000000000000000000000000000",
  "l2Erc20DefaultBridge": "0x0000000000000000000000000000000000010003",
  "l2LegacySharedBridge": "0x954ba8223a6bfec1cc3867139243a02ba0bc66e4",
  "l2SharedDefaultBridge": "0x0000000000000000000000000000000000010003",
  "l2WethBridge": "0x0000000000000000000000000000000000000000"
}
```

### Changes

- Renamed the duplicated `l2LegacySharedBridge` to `l2SharedDefaultBridge`
- Corrected its example to `0x0000000000000000000000000000000000010003`
- Corrected the `l2Erc20DefaultBridge` example, which was `0x0...0000` instead of the actual `0x0...010003`

The endpoint-level example at `openapi.json:4520` was already correct, which is likely why this went unnoticed. Only the `x-definitions` schema was affected.

### After

`mint dev` starts without the parse error and the OpenAPI tab loads. No `.mdx` file references `zks_getBridgeContracts` examples, so no other files needed changes.
